### PR TITLE
Add trove classifiers for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,20 @@ setup(
         'testing': testing_extras,
     },
     description=short_description,
-    long_description=open('README.rst').read()
+    long_description=open('README.rst').read(),
+    classifiers=[
+        'Framework :: Django',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
+        'License :: Public Domain',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ]
 )


### PR DESCRIPTION
This commit adds trove classifiers so that this package can be properly searchable on PyPI by Python and Django version. It also ensures that this package is properly marked as compatible with Python 3 for the https://caniusepython3.com/ project.

See full list of possible trove classifiers at

https://pypi.python.org/pypi?%3Aaction=list_classifiers

See the current list of "cfpb" packages marked as compatible with Python 3 at

https://pypi.org/search/?q=cfpb&c=Programming+Language+%3A%3A+Python+%3A%3A+3

I've added Python 2.7, 3.5, and 3.6 support along with Django 1.8, 1.9, 1.10, and 1.11 because those are the versions tested against by Travis and documented in the README.