### PR TITLE
Add support for streamblock children

### DIFF
--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -1,6 +1,6 @@
 from itertools import chain
 
-from wagtail.wagtailcore.blocks import ListBlock, StructBlock
+from wagtail.wagtailcore.blocks import ListBlock, StreamBlock, StructBlock
 from wagtail.wagtailcore.fields import StreamField
 
 from wagtailinventory.models import PageBlock
@@ -35,6 +35,8 @@ def get_field_blocks(value):
         else:
             child_blocks = [value.value]
     elif isinstance(block, ListBlock):
+        child_blocks = value.value
+    elif isinstance(block, StreamBlock):
         child_blocks = value.value
     else:
         child_blocks = []

--- a/wagtailinventory/tests/test_helpers.py
+++ b/wagtailinventory/tests/test_helpers.py
@@ -2,9 +2,12 @@ import json
 
 from django.test import TestCase
 
+from wagtail.wagtailcore.blocks.stream_block import StreamValue
+
 from wagtailinventory.helpers import get_page_blocks
 from wagtailinventory.tests.testapp.models import (
-    MultipleStreamFieldsPage, NoStreamFieldsPage, SingleStreamFieldPage
+    MultipleStreamFieldsPage, NestedStreamBlockPage, NoStreamFieldsPage,
+    SingleStreamFieldPage
 )
 
 
@@ -119,5 +122,32 @@ class TestGetPageBlocks(TestCase):
                 'wagtailinventory.tests.testapp.blocks.Atom',
                 'wagtailinventory.tests.testapp.blocks.Molecule',
                 'wagtailinventory.tests.testapp.blocks.Organism',
+            ]
+        )
+
+    def test_streamfield_with_child_stream_block(self):
+        page = self.make_page_with_streamfields(
+            NestedStreamBlockPage
+        )
+
+        page.content = StreamValue(
+            page.content.stream_block,
+            [{
+                'type': 'streamblock',
+                'value': [
+                    {
+                        'type': 'text',
+                        'value': 'Test content'
+                    }
+                ]
+            }],
+            True
+        )
+
+        self.assertEqual(
+            get_page_blocks(page),
+            [
+                'wagtail.wagtailcore.blocks.field_block.CharBlock',
+                'wagtail.wagtailcore.blocks.stream_block.StreamBlock',
             ]
         )

--- a/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
+++ b/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailcore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testapp', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='NestedStreamBlockPage',
+            fields=[
+                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
+                ('content', wagtail.wagtailcore.fields.StreamField([(b'streamblock', wagtail.wagtailcore.blocks.StreamBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock())]))]))
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+    ]

--- a/wagtailinventory/tests/testapp/models.py
+++ b/wagtailinventory/tests/testapp/models.py
@@ -44,3 +44,15 @@ class MultipleStreamFieldsPage(Page):
         FieldPanel('first'),
         FieldPanel('second'),
     ]
+
+
+class NestedStreamBlockPage(Page):
+    content = StreamField([
+        ('streamblock', wagtail_blocks.StreamBlock([
+            ('text', wagtail_blocks.CharBlock()),
+        ])),
+    ])
+
+    content_panels = [
+        FieldPanel('content'),
+    ]


### PR DESCRIPTION
Modifies `get_field_blocks` to return children of streamblocks. Currently it returns an empty list, so streamblock children are not included in the results of `get_page_blocks`.

@chosak