### PR TITLE
Adds Django 2.0 and Wagtail 2.0/2.1 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ source=
     wagtailinventory
 omit=
     setup.py
+    wagtailinventory/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ __pycache__/
 *.py[cod]
 .env
 .eggs
+.python-version
 
 # Django #
 #################

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,20 @@ cache: pip
 
 matrix:
   include:
-    - env: TOXENV=py27-dj18-wag18
-      python: 2.7
-    - env: TOXENV=py35-dj18-wag18
-      python: 3.5
-    - env: TOXENV=py27-dj111-wag110
-      python: 2.7
     - env: TOXENV=py27-dj111-wag113
       python: 2.7
-    - env: TOXENV=py35-dj111-wag110
-      python: 3.5
-    - env: TOXENV=py35-dj111-wag113
-      python: 3.5
-    - env: TOXENV=py36-dj111-wag110
-      python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
+    - env: TOXENV=py36-dj111-wag20
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag21
+      python: 3.6
+    - env: TOXENV=py36-dj20-wag20
+      python: 3.6
+    - env: TOXENV=py36-dj20-wag21
+      python: 3.6
     - env: TOXENV=flake8
-      python: 3.5
+      python: 3.6
 
 install:
   pip install tox

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ Compatibility
 This code has been tested for compatibility with:
 
 * Python 2.7, 3.5, 3.6
-* Django 1.8 - 1.11
-* Wagtail 1.8 - 1.13
+* Django 1.8 - 1.11, 2.0
+* Wagtail 1.8 - 1.13, 2.0 - 2.1
 
 Testing
 -------

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.8,<1.12',
+    'Django>=1.8,<2.1',
     'tqdm==4.15.0',
-    'wagtail>=1.8,<1.14',
+    'wagtail>=1.8,<2.2',
 ]
 
 
@@ -45,6 +45,10 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 2.0',
+        'Framework :: Wagtail',
+        'Framework :: Wagtail :: 1',
+        'Framework :: Wagtail :: 2',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,28 @@
 [tox]
 skipsdist=True
-envlist=py{27,35}-dj18-wag18,
-        py{27,35,36}-dj111-wag{110,113},
+envlist=py{27,36}-dj111-wag113,
+        py36-dj{111,20}-wag{20,21},
         flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage run {envbindir}/django-admin.py test {posargs}
+    coverage report
 setenv=
     DJANGO_SETTINGS_MODULE=wagtailinventory.tests.settings
 
 basepython=
     py27: python2.7
-    py35: python3.5
     py36: python3.6
 
 deps=
     mock>=1.0.0
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
-    wag18: wagtail>=1.8,<1.9
-    wag110: wagtail>=1.10,<1.11
+    dj20: Django>=2.0,<2.1
     wag113: wagtail>=1.13,<1.14
+    wag20: wagtail>=2.0,<2.1
+    wag21: wagtail>=2.1,<2.2
 
 [flake8]
 exclude=
@@ -30,6 +30,6 @@ exclude=
     wagtailinventory/tests/testapp/migrations/*.py
 
 [testenv:flake8]
-basepython=python3.5
+basepython=python3.6
 deps=flake8>=2.2.0
 commands=flake8 wagtailinventory

--- a/wagtailinventory/fixtures/test_blocks.json
+++ b/wagtailinventory/fixtures/test_blocks.json
@@ -1,0 +1,220 @@
+[
+{
+    "model": "auth.user",
+    "fields": {
+        "password": "pbkdf2_sha256$100000$RKUa1ZdWARZL$rG55GlxBES3r1bDuInG/z9IthbzqS43lehVwXGx4Ke4=",
+        "last_login": "2018-06-11T11:43:09.976",
+        "is_superuser": true,
+        "username": "admin",
+        "first_name": "",
+        "last_name": "",
+        "email": "admin@admin.admin",
+        "is_staff": true,
+        "is_active": true,
+        "date_joined": "2018-06-11T11:42:56.375",
+        "groups": [],
+        "user_permissions": []
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 3,
+    "fields": {
+        "path": "000100010001",
+        "depth": 3,
+        "numchild": 0,
+        "title": "Single StreamField page with no content",
+        "draft_title": "Single StreamField page with no content",
+        "slug": "single-streamfield-page-no-content",
+        "content_type": [
+            "testapp",
+            "singlestreamfieldpage"
+        ],
+        "live": false,
+        "has_unpublished_changes": true,
+        "url_path": "/home/single-streamfield-page-no-content/",
+        "owner": [
+            "admin"
+        ],
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "latest_revision_created_at": "2018-06-11T11:43:21.991",
+        "live_revision": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 4,
+    "fields": {
+        "path": "000100010002",
+        "depth": 3,
+        "numchild": 0,
+        "title": "Single StreamField page with content",
+        "draft_title": "Single StreamField page with content",
+        "slug": "single-streamfield-page-content",
+        "content_type": [
+            "testapp",
+            "singlestreamfieldpage"
+        ],
+        "live": false,
+        "has_unpublished_changes": true,
+        "url_path": "/home/single-streamfield-page-content/",
+        "owner": [
+            "admin"
+        ],
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "latest_revision_created_at": "2018-06-11T11:43:38.252",
+        "live_revision": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 5,
+    "fields": {
+        "path": "000100010003",
+        "depth": 3,
+        "numchild": 0,
+        "title": "Multiple StreamFields page",
+        "draft_title": "Multiple StreamFields page",
+        "slug": "multiple-streamfields-page",
+        "content_type": [
+            "testapp",
+            "multiplestreamfieldspage"
+        ],
+        "live": false,
+        "has_unpublished_changes": true,
+        "url_path": "/home/multiple-streamfields-page/",
+        "owner": [
+            "admin"
+        ],
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "latest_revision_created_at": "2018-06-11T11:44:22.660",
+        "live_revision": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 6,
+    "fields": {
+        "path": "000100010004",
+        "depth": 3,
+        "numchild": 0,
+        "title": "Nested StreamBlock page",
+        "draft_title": "Nested StreamBlock page",
+        "slug": "nested-streamblock-page",
+        "content_type": [
+            "testapp",
+            "nestedstreamblockpage"
+        ],
+        "live": false,
+        "has_unpublished_changes": true,
+        "url_path": "/home/nested-streamblock-page/",
+        "owner": [
+            "admin"
+        ],
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "latest_revision_created_at": "2018-06-11T11:44:47.772",
+        "live_revision": null
+    }
+},
+{
+    "model": "wagtailcore.page",
+    "pk": 7,
+    "fields": {
+        "path": "000100010005",
+        "depth": 3,
+        "numchild": 0,
+        "title": "No StreamFields on this page",
+        "draft_title": "No StreamFields on this page",
+        "slug": "no-streamfields-page",
+        "content_type": [
+            "testapp",
+            "nostreamfieldspage"
+        ],
+        "live": false,
+        "has_unpublished_changes": true,
+        "url_path": "/home/no-streamfields-page/",
+        "owner": [
+            "admin"
+        ],
+        "seo_title": "",
+        "show_in_menus": false,
+        "search_description": "",
+        "go_live_at": null,
+        "expire_at": null,
+        "expired": false,
+        "locked": false,
+        "first_published_at": null,
+        "last_published_at": null,
+        "latest_revision_created_at": "2018-06-11T11:45:01.819",
+        "live_revision": null
+    }
+},
+{
+    "model": "testapp.nostreamfieldspage",
+    "pk": 7,
+    "fields": {
+        "content": "Only text."
+    }
+},
+{
+    "model": "testapp.singlestreamfieldpage",
+    "pk": 3,
+    "fields": {
+        "content": "[]"
+    }
+},
+{
+    "model": "testapp.singlestreamfieldpage",
+    "pk": 4,
+    "fields": {
+        "content": "[{\"type\": \"atom\", \"value\": {\"title\": \"Atom\"}, \"id\": \"07422894-413b-4528-8f67-d7113b3bfe7a\"}]"
+    }
+},
+{
+    "model": "testapp.multiplestreamfieldspage",
+    "pk": 5,
+    "fields": {
+        "first": "[{\"type\": \"molecule\", \"value\": {\"title\": \"Molecule 1\", \"atoms\": [{\"title\": \"Atom 1\"}]}, \"id\": \"1596e627-b83d-4e33-83bf-78d741cc1456\"}]",
+        "second": "[{\"type\": \"organism\", \"value\": {\"molecules\": [{\"title\": \"Molecule 2\", \"atoms\": [{\"title\": \"Atom 2\"}]}]}, \"id\": \"7f9b97e9-fd2a-4720-a0a5-85f097c170ed\"}]"
+    }
+},
+{
+    "model": "testapp.nestedstreamblockpage",
+    "pk": 6,
+    "fields": {
+        "content": "[{\"type\": \"streamblock\", \"value\": [{\"type\": \"text\", \"value\": \"Text 1\", \"id\": \"66b7fe1b-47e5-461c-b032-f7ee28733ac0\"}], \"id\": \"0bf78fa8-2bfa-4d6b-b146-c93a4d89bc4f\"}, {\"type\": \"streamblock\", \"value\": [{\"type\": \"atom\", \"value\": {\"title\": \"Text 2\"}, \"id\": \"a5b900bd-5c10-42ef-b304-c826b25a915e\"}], \"id\": \"4b80a8f0-e202-4ac9-b93a-e1fb1d10235e\"}]"
+    }
+}
+]

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import, unicode_literals
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import formset_factory
-from wagtail.wagtailcore.models import Page
+
+try:
+    from wagtail.core.models import Page
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Page
 
 from wagtailinventory.models import PageBlock
 

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -1,7 +1,11 @@
 from itertools import chain
 
-from wagtail.wagtailcore.blocks import ListBlock, StreamBlock, StructBlock
-from wagtail.wagtailcore.fields import StreamField
+try:
+    from wagtail.core.blocks import ListBlock, StreamBlock, StructBlock
+    from wagtail.core.fields import StreamField  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.blocks import ListBlock, StreamBlock, StructBlock
+    from wagtail.wagtailcore.fields import StreamField
 
 from wagtailinventory.models import PageBlock
 

--- a/wagtailinventory/management/commands/block_inventory.py
+++ b/wagtailinventory/management/commands/block_inventory.py
@@ -1,8 +1,10 @@
-from __future__ import print_function
-
 from django.core.management import BaseCommand
 from tqdm import tqdm
-from wagtail.wagtailcore.models import Page
+
+try:
+    from wagtail.core.models import Page
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Page
 
 from wagtailinventory.helpers import (
     create_page_inventory, delete_page_inventory

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -2,12 +2,17 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from wagtail.wagtailcore.models import Page
+
+try:
+    from wagtail.core.models import Page
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Page
 
 
 @python_2_unicode_compatible
 class PageBlock(models.Model):
-    page = models.ForeignKey(Page, related_name='page_blocks')
+    page = models.ForeignKey(Page, related_name='page_blocks',
+                             on_delete=models.CASCADE)
     block = models.CharField(max_length=255, db_index=True)
 
     def __str__(self):

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
-import django
+import os
 
+import django
+import wagtail
+
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(PROJECT_DIR)
+
+DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
@@ -14,29 +22,54 @@ DATABASES = {
     },
 }
 
-INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.staticfiles',
+if wagtail.VERSION >= (2, 0):
+    WAGTAIL_APPS = (
+        'wagtail.contrib.forms',
+        'wagtail.contrib.settings',
+        'wagtail.admin',
+        'wagtail.core',
+        'wagtail.documents',
+        'wagtail.images',
+        'wagtail.sites',
+        'wagtail.users',
+    )
 
-    'taggit',
+    WAGTAIL_MIDDLEWARE = (
+        'wagtail.core.middleware.SiteMiddleware',
+    )
 
-    'wagtail.contrib.modeladmin',
-    'wagtail.contrib.settings',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailcore',
-    'wagtail.wagtailforms',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailusers',
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        'default': {
+            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
+        },
+        'custom': {
+            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        },
+    }
+else:
+    WAGTAIL_APPS = (
+        'wagtail.contrib.settings',
+        'wagtail.wagtailadmin',
+        'wagtail.wagtailcore',
+        'wagtail.wagtaildocs',
+        'wagtail.wagtailforms',
+        'wagtail.wagtailimages',
+        'wagtail.wagtailsites',
+        'wagtail.wagtailusers',
+    )
 
-    'wagtailinventory',
-    'wagtailinventory.tests.testapp',
-)
+    WAGTAIL_MIDDLEWARE = (
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
+    )
 
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        'default': {
+            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
+        },
+        'custom': {
+            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        },
+    }
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (
@@ -44,10 +77,9 @@ if django.VERSION >= (1, 10):
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    )
+    ) + WAGTAIL_MIDDLEWARE
 else:
     MIDDLEWARE_CLASSES = (
         'django.middleware.common.CommonMiddleware',
@@ -57,9 +89,26 @@ else:
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    )
+    ) + WAGTAIL_MIDDLEWARE
 
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.staticfiles',
+
+    'taggit',
+) + WAGTAIL_APPS + (
+    'wagtailinventory',
+    'wagtailinventory.tests.testapp',
+)
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'
 
 TEMPLATES = [
     {
@@ -81,11 +130,4 @@ TEMPLATES = [
 
 WAGTAIL_SITE_NAME = 'Test Site'
 
-WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    'default': {
-        'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea'
-    },
-    'custom': {
-        'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
-    },
-}
+ROOT_URLCONF = 'wagtailinventory.tests.urls'

--- a/wagtailinventory/tests/test_models.py
+++ b/wagtailinventory/tests/test_models.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
-from wagtail.wagtailcore.models import Page
+try:
+    from wagtail.core.models import Page
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Page
+
 from wagtailinventory.models import PageBlock
 
 

--- a/wagtailinventory/tests/test_wagtail_hooks.py
+++ b/wagtailinventory/tests/test_wagtail_hooks.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from wagtailinventory import wagtail_hooks

--- a/wagtailinventory/tests/testapp/blocks.py
+++ b/wagtailinventory/tests/testapp/blocks.py
@@ -1,4 +1,7 @@
-from wagtail.wagtailcore import blocks
+try:
+    from wagtail.core import blocks
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore import blocks
 
 
 class Atom(blocks.StructBlock):

--- a/wagtailinventory/tests/testapp/migrations/0001_initial.py
+++ b/wagtailinventory/tests/testapp/migrations/0001_initial.py
@@ -3,8 +3,13 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.wagtailcore.blocks
-import wagtail.wagtailcore.fields
+
+try:
+    from wagtail.core import blocks as core_blocks
+    from wagtail.core import fields as core_fields  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore import blocks as core_blocks
+    from wagtail.wagtailcore import fields as core_fields
 
 
 class Migration(migrations.Migration):
@@ -20,8 +25,8 @@ class Migration(migrations.Migration):
             name='MultipleStreamFieldsPage',
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('first', wagtail.wagtailcore.fields.StreamField([(b'atom', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])), (b'molecule', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock()), (b'atoms', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])))])), (b'organism', wagtail.wagtailcore.blocks.StructBlock([(b'molecules', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock()), (b'atoms', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])))])))]))])),
-                ('second', wagtail.wagtailcore.fields.StreamField([(b'atom', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])), (b'molecule', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock()), (b'atoms', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])))])), (b'organism', wagtail.wagtailcore.blocks.StructBlock([(b'molecules', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock()), (b'atoms', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])))])))]))])),
+                ('first', core_fields.StreamField([('atom', core_blocks.StructBlock([('title', core_blocks.CharBlock())])), ('molecule', core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])), ('organism', core_blocks.StructBlock([('molecules', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])))]))])),
+                ('second', core_fields.StreamField([('atom', core_blocks.StructBlock([('title', core_blocks.CharBlock())])), ('molecule', core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])), ('organism', core_blocks.StructBlock([('molecules', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])))]))])),
             ],
             options={
                 'abstract': False,
@@ -43,7 +48,7 @@ class Migration(migrations.Migration):
             name='SingleStreamFieldPage',
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('content', wagtail.wagtailcore.fields.StreamField([(b'text', wagtail.wagtailcore.blocks.CharBlock()), (b'atom', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])), (b'molecule', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock()), (b'atoms', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])))])), (b'organism', wagtail.wagtailcore.blocks.StructBlock([(b'molecules', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock()), (b'atoms', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())])))])))]))])),
+                ('content', core_fields.StreamField([('text', core_blocks.CharBlock()), ('atom', core_blocks.StructBlock([('title', core_blocks.CharBlock())])), ('molecule', core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])), ('organism', core_blocks.StructBlock([('molecules', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])))]))])),
             ],
             options={
                 'abstract': False,

--- a/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
+++ b/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
@@ -3,8 +3,13 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.wagtailcore.blocks
-import wagtail.wagtailcore.fields
+
+try:
+    from wagtail.core import blocks as core_blocks
+    from wagtail.core import fields as core_fields  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore import blocks as core_blocks
+    from wagtail.wagtailcore import fields as core_fields
 
 
 class Migration(migrations.Migration):
@@ -18,7 +23,7 @@ class Migration(migrations.Migration):
             name='NestedStreamBlockPage',
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('content', wagtail.wagtailcore.fields.StreamField([(b'streamblock', wagtail.wagtailcore.blocks.StreamBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock()), (b'atom', wagtail.wagtailcore.blocks.StructBlock([(b'title', wagtail.wagtailcore.blocks.CharBlock())]))]))])),
+                ('content', core_fields.StreamField([('streamblock', core_blocks.StreamBlock([('text', core_blocks.CharBlock()), ('atom', core_blocks.StructBlock([('title', core_blocks.CharBlock())]))]))])),
             ],
             options={
                 'abstract': False,

--- a/wagtailinventory/tests/testapp/migrations/0003_single_content_block_optional.py
+++ b/wagtailinventory/tests/testapp/migrations/0003_single_content_block_optional.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+try:
+    from wagtail.core import blocks as core_blocks
+    from wagtail.core import fields as core_fields  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore import blocks as core_blocks
+    from wagtail.wagtailcore import fields as core_fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testapp', '0002_nested_stream_block_page'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='singlestreamfieldpage',
+            name='content',
+            field=core_fields.StreamField([('atom', core_blocks.StructBlock([('title', core_blocks.CharBlock())])), ('molecule', core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])), ('organism', core_blocks.StructBlock([('molecules', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock()), ('atoms', core_blocks.ListBlock(core_blocks.StructBlock([('title', core_blocks.CharBlock())])))])))]))], blank=True),
+        ),
+    ]

--- a/wagtailinventory/tests/testapp/models.py
+++ b/wagtailinventory/tests/testapp/models.py
@@ -1,8 +1,15 @@
 from django.db import models
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
-from wagtail.wagtailcore import blocks as wagtail_blocks
-from wagtail.wagtailcore.fields import StreamField
-from wagtail.wagtailcore.models import Page
+
+try:
+    from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
+    from wagtail.core import blocks as wagtail_blocks  # pragma: no cover
+    from wagtail.core.fields import StreamField  # pragma: no cover
+    from wagtail.core.models import Page  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
+    from wagtail.wagtailcore import blocks as wagtail_blocks
+    from wagtail.wagtailcore.fields import StreamField
+    from wagtail.wagtailcore.models import Page
 
 from wagtailinventory.tests.testapp import blocks
 
@@ -10,21 +17,20 @@ from wagtailinventory.tests.testapp import blocks
 class NoStreamFieldsPage(Page):
     content = models.TextField()
 
-    content_panels = [
+    content_panels = Page.content_panels + [
         FieldPanel('content'),
     ]
 
 
 class SingleStreamFieldPage(Page):
     content = StreamField([
-        ('text', wagtail_blocks.CharBlock()),
         ('atom', blocks.Atom()),
         ('molecule', blocks.Molecule()),
         ('organism', blocks.Organism()),
-    ])
+    ], blank=True)
 
-    content_panels = [
-        FieldPanel('content'),
+    content_panels = Page.content_panels + [
+        StreamFieldPanel('content'),
     ]
 
 
@@ -40,9 +46,9 @@ class MultipleStreamFieldsPage(Page):
         ('organism', blocks.Organism()),
     ])
 
-    content_panels = [
-        FieldPanel('first'),
-        FieldPanel('second'),
+    content_panels = Page.content_panels + [
+        StreamFieldPanel('first'),
+        StreamFieldPanel('second'),
     ]
 
 
@@ -54,6 +60,6 @@ class NestedStreamBlockPage(Page):
         ])),
     ])
 
-    content_panels = [
-        FieldPanel('content'),
+    content_panels = Page.content_panels + [
+        StreamFieldPanel('content'),
     ]

--- a/wagtailinventory/tests/urls.py
+++ b/wagtailinventory/tests/urls.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+from django.conf.urls import include, url
+
+
+try:
+    from wagtail.admin import urls as wagtailadmin_urls
+    from wagtail.core import urls as wagtailcore_urls  # pragma: no cover
+    from wagtail.documents import urls as wagtaildocs_urls  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+    from wagtail.wagtailcore import urls as wagtailcore_urls
+    from wagtail.wagtaildocs import urls as wagtaildocs_urls
+
+
+urlpatterns = [
+    url(r'^admin/', include(wagtailadmin_urls)),
+    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'', include(wagtailcore_urls)),
+]
+
+
+if settings.DEBUG:
+    from django.conf.urls.static import static
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+
+    urlpatterns += staticfiles_urlpatterns()
+    urlpatterns += static(
+        settings.MEDIA_URL,
+        document_root=settings.MEDIA_ROOT
+    )

--- a/wagtailinventory/urls.py
+++ b/wagtailinventory/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url
+
+from wagtailinventory.views import SearchView
+
+
+app_name = 'wagtailinventory'
+
+
+urlpatterns = [
+    url(r'^$', SearchView.as_view(), name='search'),
+]

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -4,7 +4,11 @@ from django.http import HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.generic import View
 from wagtail.utils.pagination import paginate, replace_page_in_query
-from wagtail.wagtailcore.models import Page
+
+try:
+    from wagtail.core.models import Page
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Page
 
 from wagtailinventory.forms import PageBlockQueryFormSet
 

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -1,14 +1,23 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
-from django.core.urlresolvers import reverse
-from wagtail.wagtailadmin.menu import MenuItem
-from wagtail.wagtailcore import hooks
 
+try:
+    from django.urls import reverse
+except ImportError:  # pragma: no cover; fallback for Django <1.10
+    from django.core.urlresolvers import reverse
+
+try:
+    from wagtail.admin.menu import MenuItem
+    from wagtail.core import hooks  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailadmin.menu import MenuItem
+    from wagtail.wagtailcore import hooks
+
+from wagtailinventory import urls
 from wagtailinventory.helpers import (
     create_page_inventory, delete_page_inventory, update_page_inventory
 )
-from wagtailinventory.views import SearchView
 
 
 @hooks.register('after_create_page')
@@ -29,13 +38,7 @@ def do_after_page_dete(request, page):
 @hooks.register('register_admin_urls')
 def register_inventory_urls():
     return [
-        url(
-            r'^inventory/',
-            include(
-                [url(r'$', SearchView.as_view(), name='search')],
-                namespace='wagtailinventory'
-            )
-        ),
+        url(r'^inventory/', include(urls, namespace='wagtailinventory')),
     ]
 
 


### PR DESCRIPTION
This change adds support for Django 2.0 and Wagtail 2.0/2.1 to this package. The README has been updated to reflect the change.

A `.coveragerc` file has been added to more helpfully limit test code coverage and the test runner now dumps coverage to console for easier reviewing. These changes also include a new test fixture for easier testing of blocks.

Fixes #8.

To verify this change against Django 2.0 and Wagtail 2.0:

1. Create a new isolated virtualenv with Python 3.6 named `testwi`.

    ```
    $ mkvirtualenv --no-site-packages --python=python3.6 testwi
    ```

2. Install this PR into the virtualenv. Pulls in Wagtail/Django 2. [This open issue](https://github.com/python-pillow/Pillow/issues/3068) means that at least for now on Macs, you need to override the version of Pillow that gets pulled in from those.

    ```sh
    $ pip install git+https://github.com/chosak/wagtail-inventory.git@wagtail-django-2
    $ pip install Pillow!=5.1.0
    ```

3. Create a new Wagtail project named `myproject`.

    ```sh
    $ wagtail start myproject
    $ cd myproject
    ```

4. Edit project settings to add modeladmin, the wagtail-inventory app and its test app, along with Wagtail modeladmin, for access to a test page class and block types.

    ```sh
    diff --git a/myproject/settings/base.py b/myproject/settings/base.py
    index fe5d391..7e8c232 100644
    --- a/myproject/settings/base.py
    +++ b/myproject/settings/base.py
    @@ -48,6 +48,8 @@ INSTALLED_APPS = [
         'django.contrib.sessions',
         'django.contrib.messages',
         'django.contrib.staticfiles',
    +
    +    'wagtail.contrib.modeladmin',
    +    'wagtailinventory',
    +    'wagtailinventory.tests.testapp',
     ]

     MIDDLEWARE = [
    ```

5. Create a database and a superuser.

    ```sh
    $ ./manage.py migrate
    $ ./manage.py createsuperuser
    ```

6. Run the `block_inventory` command to initialize the block table.

    ```sh
    $ ./manage.py block_inventory
    ```

7. Run your local server.

    ```sh
    $ ./manage.py runserver
    ```

9. Login to the admin at http://localhost:8000/admin/ with the superuser you just created. Under Settings, Block Inventory you should see the two default Wagtail pages. You shouldn't see any options in the dropdown because the default pages don't include StreamField blocks.

10. Now we'll add a new page that does include StreamField blocks. In the sidebar, click Pages, Home. Click the Add Child Page button and choose one of the test page types, say "Multiple stream fields page".

    Add some StreamField content, then click Save Draft.

11. If you go back to Settings, Block Inventory, you'll see that the dropdown menus now include the block types that you included.

    Play around with adding/deleting content from the page to see how the inventory results change. Results should automatically be updated whenever the page is saved.

Thanks to @alanmoo for contributing to these changes.