### PR TITLE
Fix broken pagination in search results

### DIFF
--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -32,7 +32,7 @@
       </h2>
 
       {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
-      {% paginate pages base_url=base_url classnames="navigate-pages" %}
+      {% include "wagtailadmin/shared/pagination_nav.html" with items=pages %}
     </div>
   {% else %}
     <div class="nice-padding">

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.http import HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.generic import View
-from wagtail.utils.pagination import paginate, replace_page_in_query
+from wagtail.utils.pagination import paginate
 
 try:
     from wagtail.core.models import Page
@@ -33,7 +33,6 @@ class SearchView(View):
             page.can_choose = True
 
         return render(request, self.template_name, {
-            'base_url': replace_page_in_query(request.GET.urlencode(), None),
             'formset': formset,
             'pages': pages,
         })


### PR DESCRIPTION
The changes in #11 to add Django/Wagtail 2.x support made a slight change to how the wagtail-inventory search URL is defined:

https://github.com/cfpb/wagtail-inventory/commit/5900a7993ba5c086206d644f32d144192678effc#diff-e5cdc1d4255de591a575368291bee269L30

Unfortunately, this broke pagination of wagtail-inventory results in the admin. In version 0.4.2 and previous, the admin page would erroneously load with any URL, e.g. /admin/inventory/anything?foo=bar... Along with this, the use of [`replace_page_in_query`](https://github.com/wagtail/wagtail/blob/f0eef2fc88043ba627b89125876f1cfe53b7fc51/wagtail/utils/pagination.py#L23) to generate page URLs wasn't creating proper URLs. It so happened that the combination of these two things made working (if ugly) URLs for pagination, but the change in 0.5 broke this.

This commit fixes pagination by leveraging the Wagtail [pagination_nav](https://github.com/wagtail/wagtail/blob/v2.1.1/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html) template, which handles generating pagination URLs for us.