### PR TITLE
version bumps to allow current django and wagtail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.8,<2.1',
+    'Django>=1.8,<=2.1',
     'tqdm==4.15.0',
-    'wagtail>=1.8,<2.2',
+    'wagtail>=1.8,<=2.4',
 ]
 
 


### PR DESCRIPTION
This addresses https://github.com/cfpb/wagtail-inventory/issues/17, by upping the Django and Wagtail version requirements to include the current versions, which should still be API compatible. (Note that I had no good way to rigorously test this locally)