### PR TITLE
Add support for Wagtail 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,11 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj20-wag20
       python: 3.6
-    - env: TOXENV=py36-dj20-wag24
+    - env: TOXENV=py36-dj20-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag25
+    - env: TOXENV=py36-dj20-wag26
       python: 3.6
-    - env: TOXENV=py36-dj21-wag24
-      python: 3.6
-    - env: TOXENV=py36-dj22-wag25
+    - env: TOXENV=py36-dj22-wag26
       python: 3.6
     - env: TOXENV=flake8
       python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ This code has been tested for compatibility with:
 
 * Python 2.7, 3.5, 3.6
 * Django 1.8 - 1.11, 2.0 - 2.2
-* Wagtail 1.8 - 1.13, 2.0 - 2.5
+* Wagtail 1.8 - 1.13, 2.0 - 2.6
 
 Testing
 -------

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'Django>=1.8,<2.3',
     'tqdm==4.15.0',
-    'wagtail>=1.8,<2.6',
+    'wagtail>=1.8,<2.7',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 skipsdist=True
 envlist=py{27,36}-dj111-wag113,
-        py36-dj{111,20}-wag{20},
-        py36-dj{20,21}-wag{24},
-        py36-dj{20,22}-wag{25},
+        py36-dj{111,20}-wag20,
+        py36-dj20-wag23,
+        py36-dj{20,22}-wag26,
         flake8
 
 [testenv]
@@ -22,12 +22,11 @@ deps=
     mock>=1.0.0
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag20: wagtail>=2.0,<2.1
-    wag24: wagtail>=2.4,<2.5
-    wag25: wagtail>=2.5,<2.6
+    wag23: wagtail>=2.3,<2.4
+    wag26: wagtail>=2.6,<2.7
 
 [flake8]
 exclude=

--- a/wagtailinventory/management/commands/block_inventory.py
+++ b/wagtailinventory/management/commands/block_inventory.py
@@ -15,5 +15,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         delete_page_inventory()
 
-        for page in tqdm(Page.objects.all()):
+        pages = Page.objects.all()
+
+        if options.get('verbosity'):  # pragma: no cover
+            pages = tqdm(pages)
+
+        for page in pages:
             create_page_inventory(page)

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -1,0 +1,57 @@
+from django.core.management import call_command
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.six.moves.urllib.parse import urlencode
+
+try:
+    from wagtail.core.models import Page
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Page
+
+from wagtail.tests.utils import WagtailTestUtils
+
+
+class SearchViewTests(WagtailTestUtils, TestCase):
+    fixtures = ['test_blocks.json']
+
+    def setUp(self):
+        self.login()
+
+    def get(self, params=None):
+        path = reverse('wagtailinventory:search')
+
+        if params:
+            path += '?' + urlencode(params)
+
+        return self.client.get(path)
+
+    def test_empty_query_returns_200_and_all_pages_ordered_by_title(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context['pages'].object_list,
+            list(Page.objects.order_by('title'))
+        )
+
+    def test_get_bad_formset_query_returns_400(self):
+        response = self.get({
+            'form-TOTAL_FORMS': 1,
+            'form-INITIAL_FORMS': 0,
+            'form-0-has': 'invalid',
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_valid_query_returns_200_and_only_appropriate_pages(self):
+        call_command('block_inventory', verbosity=0)
+
+        response = self.get({
+            'form-TOTAL_FORMS': 1,
+            'form-INITIAL_FORMS': 0,
+            'form-0-has': 'includes',
+            'form-0-block': 'wagtailinventory.tests.testapp.blocks.Organism',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context['pages'].object_list,
+            [Page.objects.get(slug='multiple-streamfields-page')]
+        )


### PR DESCRIPTION
This change adds support for Wagtail 2.6. It also corrects a deprecation warning that starts appearing in Wagtail 2.5 due to deprecation of `wagtail.utils.pagination`. For version 2.5 or newer, we instead use Django's paginator [as recommended by the Wagtail docs](https://docs.wagtail.io/en/latest/releases/2.5.html#changes-to-admin-pagination-helpers).

Fixes #22.