### PR TITLE
Support Wagtail 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
-    - env: TOXENV=py37-dj20-wag27
-      python: 3.7
-    - env: TOXENV=py37-dj22-wag27
-      python: 3.7
+    - env: TOXENV=py38-dj20-wag27
+      python: 3.8
+    - env: TOXENV=py38-dj22-wag27
+      python: 3.8
     - env: TOXENV=flake8
       python: 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: pip
 
 matrix:
   include:
-    - env: TOXENV=py27-dj111-wag113
-      python: 2.7
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj111-wag20
@@ -14,9 +12,9 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag26
+    - env: TOXENV=py36-dj20-wag27
       python: 3.6
-    - env: TOXENV=py36-dj22-wag26
+    - env: TOXENV=py36-dj22-wag27
       python: 3.6
     - env: TOXENV=flake8
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache: pip
 
 matrix:
   include:
+    - env: TOXENV=flake8
+      python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj111-wag20
@@ -12,16 +14,14 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag27
+    - env: TOXENV=py36-dj20-wag28
       python: 3.6
-    - env: TOXENV=py36-dj22-wag27
+    - env: TOXENV=py36-dj22-wag28
       python: 3.6
-    - env: TOXENV=py38-dj20-wag27
+    - env: TOXENV=py38-dj20-wag28
       python: 3.8
-    - env: TOXENV=py38-dj22-wag27
+    - env: TOXENV=py38-dj22-wag28
       python: 3.8
-    - env: TOXENV=flake8
-      python: 3.6
 
 install:
   pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj22-wag27
       python: 3.6
+    - env: TOXENV=py37-dj20-wag27
+      python: 3.7
+    - env: TOXENV=py37-dj22-wag27
+      python: 3.7
     - env: TOXENV=flake8
       python: 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
-    - env: TOXENV=py36-dj111-wag20
-      python: 3.6
-    - env: TOXENV=py36-dj20-wag20
+    - env: TOXENV=py36-dj111-wag23
       python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ This code has been tested for compatibility with:
 
 * Python 3.6, 3.8
 * Django 1.11, 2.0, 2.2
-* Wagtail 1.13, 2.0 - 2.7
+* Wagtail 1.13, 2.3, 2.8
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.6, 3.8
-* Django 1.11, 2.0, 2.2
-* Wagtail 1.13, 2.3, 2.8
+* Python 3
+* Django 1.8-1.11, 2.0-2.2
+* Wagtail 1.13, 2.0-2.8
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 2.7, 3.5, 3.6
+* Python 3.5, 3.6
 * Django 1.8 - 1.11, 2.0 - 2.2
-* Wagtail 1.8 - 1.13, 2.0 - 2.6
+* Wagtail 1.8 - 1.13, 2.0 - 2.7
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.5, 3.6
-* Django 1.8 - 1.11, 2.0 - 2.2
-* Wagtail 1.8 - 1.13, 2.0 - 2.7
+* Python 3.6, 3.7, 3.8
+* Django 1.11, 2.0 - 2.2
+* Wagtail 1.13, 2.0 - 2.7
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,12 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3
-* Django 1.8-1.11, 2.0-2.2
-* Wagtail 1.13, 2.0-2.8
+* Python 3.6, 3.8
+* Django 1.11, 2.0, 2.2
+* Wagtail 1.13, 2.3, 2.8
+
+It should be compatible at all intermediate versions, as well.
+If you find that it is not, please [file an issue](issues/new).
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,8 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.6, 3.7, 3.8
-* Django 1.11, 2.0 - 2.2
+* Python 3.6, 3.8
+* Django 1.11, 2.0, 2.2
 * Wagtail 1.13, 2.0 - 2.7
 
 Testing

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'Django>=1.8,<2.3',
     'tqdm==4.15.0',
-    'wagtail>=1.8,<2.7',
+    'wagtail>=1.8,<2.8',
 ]
 
 
@@ -54,8 +54,6 @@ setup(
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,7 @@ setup(
     long_description=open('README.rst').read(),
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
@@ -55,7 +52,8 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'Django>=1.8,<2.3',
     'tqdm==4.15.0',
-    'wagtail>=1.8,<2.8',
+    'wagtail>=1.8,<2.9',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,12 @@ setup(
     long_description=open('README.rst').read(),
     classifiers=[
         'Framework :: Django',
+        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -51,7 +55,5 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -53,7 +52,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=py36-dj111-wag113,
         py36-dj{111,20}-wag20,
-        py{36,38}-dj{20}-wag23,
-        py{36,38}-dj{20,22}-wag27,
+        py36-dj{20}-wag23,
+        py{36,38}-dj{20,22}-wag28,
         flake8
 
 [testenv]
@@ -26,7 +26,7 @@ deps=
     wag113: wagtail>=1.13,<1.14
     wag20: wagtail>=2.0,<2.1
     wag23: wagtail>=2.3,<2.4
-    wag27: wagtail>=2.7,<2.8
+    wag28: wagtail>=2.8,<2.9
 
 [flake8]
 exclude=

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=py36-dj111-wag113,
         py36-dj{111,20}-wag20,
-        py{36,37}-dj{20}-wag23,
-        py{36,37}-dj{20,22}-wag27,
+        py{36,38}-dj{20}-wag23,
+        py{36,38}-dj{20,22}-wag27,
         flake8
 
 [testenv]
@@ -16,7 +16,6 @@ setenv=
 
 basepython=
     py36: python3.6
-    py37: python3.7
     py38: python3.8
 
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj111-wag113,
+envlist=py{36}-dj111-wag113,
         py36-dj{111,20}-wag20,
         py36-dj20-wag23,
-        py36-dj{20,22}-wag26,
+        py36-dj{20,22}-wag27,
         flake8
 
 [testenv]
@@ -15,7 +15,6 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailinventory.tests.settings
 
 basepython=
-    py27: python2.7
     py36: python3.6
 
 deps=
@@ -26,7 +25,7 @@ deps=
     wag113: wagtail>=1.13,<1.14
     wag20: wagtail>=2.0,<2.1
     wag23: wagtail>=2.3,<2.4
-    wag26: wagtail>=2.6,<2.7
+    wag27: wagtail>=2.7,<2.8
 
 [flake8]
 exclude=

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
-envlist=py{36,37}-dj111-wag113,
-        py{36,37}-dj{111,20}-wag20,
+envlist=py36-dj111-wag113,
+        py36-dj{111,20}-wag20,
         py{36,37}-dj{20}-wag23,
         py{36,37}-dj{20,22}-wag27,
         flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py36-dj111-wag113,
+envlist=py36-dj111-wag{113,23},
         py36-dj{111,20}-wag20,
         py36-dj{20}-wag23,
         py{36,38}-dj{20,22}-wag28,

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 skipsdist=True
-envlist=py{36}-dj111-wag113,
-        py36-dj{111,20}-wag20,
-        py36-dj20-wag23,
-        py36-dj{20,22}-wag27,
+envlist=py{36,37}-dj111-wag113,
+        py{36,37}-dj{111,20}-wag20,
+        py{36,37}-dj{20}-wag23,
+        py{36,37}-dj{20,22}-wag27,
         flake8
 
 [testenv]
@@ -16,6 +16,8 @@ setenv=
 
 basepython=
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
 
 deps=
     mock>=1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps=
     mock>=1.0.0
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag20: wagtail>=2.0,<2.1


### PR DESCRIPTION
Support production version of Python 3.6 and latest version of Python 3.8
Support latest version of Wagtail 2.8

Remove Python 2.7 and add Python 3.8 to:
* README.rst
* setup.py
* tox.ini
* travis.yml
Add support for Wagtail 2.8 to `tox.ini`, `setup.py`, and `travis.yml`

Testing
$ tox
```
...
  py36-dj111-wag113: commands succeeded
  py36-dj111-wag23: commands succeeded
  py36-dj111-wag20: commands succeeded
  py36-dj20-wag20: commands succeeded
  py36-dj20-wag23: commands succeeded
  py36-dj20-wag28: commands succeeded
  py36-dj22-wag28: commands succeeded
  py38-dj20-wag28: commands succeeded
  py38-dj22-wag28: commands succeeded
  flake8: commands succeeded
  congratulations :)
```