### PR TITLE
Fix broken README link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ This code has been tested for compatibility with:
 * Django 1.11, 2.0, 2.2
 * Wagtail 1.13, 2.3, 2.8
 
-It should be compatible at all intermediate versions, as well.
-If you find that it is not, please [file an issue](issues/new).
+It should be compatible with all intermediate versions, as well.
+If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.
 
 Testing
 -------


### PR DESCRIPTION
#25 made some edits to the README, and added a link in Markdown format, where it should have instead been in RST format. This commit fixes that link.