### PR TITLE
Remove Wagtail 1.13 support, add Django 2.2 import support, and add Black for autoformatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ cache: pip
 
 matrix:
   include:
-    - env: TOXENV=flake8
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag113
+    - env: TOXENV=lint
       python: 3.6
     - env: TOXENV=py36-dj111-wag23
       python: 3.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,23 @@ tests that validate implemented features and the presence or lack of defects.
 Additionally, the code should follow any stylistic and architectural guidelines
 prescribed by the project. In the absence of such guidelines, mimic the styles
 and patterns in the existing code-base.
+
+
+## Style
+
+This project uses [`black`](https://github.com/psf/black) to format code,
+[`isort`](https://github.com/timothycrosley/isort) to format imports,
+and [`flake8`](https://gitlab.com/pycqa/flake8).
+
+You can format code and imports by calling:
+
+```
+black wagtailinventory
+isort --recursive wagtailinventory
+```
+
+And you can check for style, import order, and other linting by using:
+
+```
+tox -e lint
+```

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ This code has been tested for compatibility with:
 
 * Python 3.6, 3.8
 * Django 1.11, 2.0, 2.2
-* Wagtail 1.13, 2.3, 2.8
+* Wagtail 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.black]
+line-length = 79
+target-version = ['py36', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.tox
+    | \*.egg-info
+    | _build
+    | build
+    | dist
+    | migrations
+    | site
+    | \*.json
+    | \*.csv
+  )/
+)
+'''
+
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "Django>=1.8,<2.3",
+    "Django>=1.11,<2.3",
     "tqdm==4.15.0",
     "wagtail>=2.3,<2.9",
 ]
@@ -36,10 +36,7 @@ setup(
     extras_require={"testing": testing_extras,},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 1.10",
         "Framework :: Django :: 1.11",
-        "Framework :: Django :: 1.8",
-        "Framework :: Django :: 1.9",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",

--- a/setup.py
+++ b/setup.py
@@ -2,55 +2,53 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.8,<2.3',
-    'tqdm==4.15.0',
-    'wagtail>=1.8,<2.9',
+    "Django>=1.8,<2.3",
+    "tqdm==4.15.0",
+    "wagtail>=1.8,<2.9",
 ]
 
 
 setup_requires = [
-    'setuptools-git-version==1.0.3',
+    "setuptools-git-version==1.0.3",
 ]
 
 
 testing_extras = [
-    'coverage>=3.7.0',
-    'flake8>=2.2.0',
-    'mock>=1.0.0',
+    "coverage>=3.7.0",
+    "flake8>=2.2.0",
+    "mock>=1.0.0",
 ]
 
 setup(
-    name='wagtail-inventory',
-    url='https://github.com/cfpb/wagtail-inventory',
-    author='CFPB',
-    author_email='tech@cfpb.gov',
-    description='Lookup Wagtail pages by block content',
-    long_description=open('README.rst').read(),
-    license='CCO',
-    version='1.0',
-    version_format='{tag}.dev{commitcount}+{gitsha}',
+    name="wagtail-inventory",
+    url="https://github.com/cfpb/wagtail-inventory",
+    author="CFPB",
+    author_email="tech@cfpb.gov",
+    description="Lookup Wagtail pages by block content",
+    long_description=open("README.rst").read(),
+    license="CCO",
+    version="1.0",
+    version_format="{tag}.dev{commitcount}+{gitsha}",
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
     setup_requires=setup_requires,
-    extras_require={
-        'testing': testing_extras,
-    },
+    extras_require={"testing": testing_extras,},
     classifiers=[
-        'Framework :: Django',
-        'Framework :: Django :: 1.10',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Wagtail',
-        'Framework :: Wagtail :: 1',
-        'Framework :: Wagtail :: 2',
-        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
-        'License :: Public Domain',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-    ]
+        "Framework :: Django",
+        "Framework :: Django :: 1.10",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 1.8",
+        "Framework :: Django :: 1.9",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Wagtail",
+        "Framework :: Wagtail :: 1",
+        "Framework :: Wagtail :: 2",
+        "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+        "License :: Public Domain",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 install_requires = [
     "Django>=1.8,<2.3",
     "tqdm==4.15.0",
-    "wagtail>=1.8,<2.9",
+    "wagtail>=2.3,<2.9",
 ]
 
 
@@ -44,7 +44,6 @@ setup(
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 1",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py36-dj111-wag{113,23},
-        py36-dj20-wag23,
+envlist=py36-dj{111,20}-wag23,
         py{36,38}-dj{20,22}-wag28,
         lint
 
@@ -22,7 +21,6 @@ deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj22: Django>=2.2,<2.3
-    wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist=True
-envlist=py36-dj{111,20}-wag23,
+envlist=lint,
+        py36-dj{111,20}-wag23,
         py{36,38}-dj{20,22}-wag28,
-        lint
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist=True
 envlist=py36-dj111-wag{113,23},
         py36-dj20-wag23,
         py{36,38}-dj{20,22}-wag28,
-        flake8
+        lint
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -26,12 +26,33 @@ deps=
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 
+[testenv:lint]
+recreate=False
+basepython=python3.6
+deps=
+    black
+    flake8
+    isort
+commands=
+    black --check wagtailinventory setup.py
+    flake8 wagtailinventory
+    isort --check-only --diff --recursive wagtailinventory
+
 [flake8]
+ignore=E731,W503,W504
 exclude=
     wagtailinventory/migrations/*.py,
     wagtailinventory/tests/testapp/migrations/*.py
 
-[testenv:flake8]
-basepython=python3.6
-deps=flake8>=2.2.0
-commands=flake8 wagtailinventory
+[isort]
+combine_as_imports=1
+lines_after_imports=2
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_future_library=future
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -2,13 +2,8 @@ from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import formset_factory
 
+from wagtail.core.models import Page
 from wagtailinventory.models import PageBlock
-
-
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
 
 
 class PageBlockQueryForm(forms.Form):

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -4,40 +4,42 @@ from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import formset_factory
 
+from wagtailinventory.models import PageBlock
+
+
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
 
-from wagtailinventory.models import PageBlock
-
 
 class PageBlockQueryForm(forms.Form):
-    INCLUDES_BLOCK = 'includes'
-    EXCLUDES_BLOCK = 'excludes'
+    INCLUDES_BLOCK = "includes"
+    EXCLUDES_BLOCK = "excludes"
 
     block = forms.ChoiceField(
         choices=(),
         required=False,
-        label='Block type',
-        widget=forms.Select(attrs={'style': 'width: 50%'})
+        label="Block type",
+        widget=forms.Select(attrs={"style": "width: 50%"}),
     )
 
     has = forms.ChoiceField(
         choices=((c, c) for c in (INCLUDES_BLOCK, EXCLUDES_BLOCK)),
         label=None,
-        widget=forms.Select(attrs={'style': 'width: 100px'})
+        widget=forms.Select(attrs={"style": "width: 100px"}),
     )
 
     def __init__(self, *args, **kwargs):
         super(PageBlockQueryForm, self).__init__(*args, **kwargs)
-        blocks = PageBlock.objects \
-            .values_list('block', flat=True) \
-            .distinct() \
-            .order_by('block')
+        blocks = (
+            PageBlock.objects.values_list("block", flat=True)
+            .distinct()
+            .order_by("block")
+        )
 
         block_choices = BLANK_CHOICE_DASH + [(b, b) for b in blocks]
-        self.fields['block'].choices = block_choices
+        self.fields["block"].choices = block_choices
 
 
 class BasePageBlockQueryFormSet(forms.BaseFormSet):
@@ -48,14 +50,14 @@ class BasePageBlockQueryFormSet(forms.BaseFormSet):
             if not form.is_valid():
                 continue
 
-            form_block = form.cleaned_data.get('block')
+            form_block = form.cleaned_data.get("block")
 
             if not form_block:
                 continue
 
-            condition = {'page_blocks__block': form_block}
+            condition = {"page_blocks__block": form_block}
 
-            if form.cleaned_data['has'] == form.INCLUDES_BLOCK:
+            if form.cleaned_data["has"] == form.INCLUDES_BLOCK:
                 qs = qs.filter(**condition)
             else:
                 qs = qs.exclude(**condition)
@@ -64,8 +66,5 @@ class BasePageBlockQueryFormSet(forms.BaseFormSet):
 
 
 PageBlockQueryFormSet = formset_factory(
-    PageBlockQueryForm,
-    formset=BasePageBlockQueryFormSet,
-    extra=3,
-    max_num=3
+    PageBlockQueryForm, formset=BasePageBlockQueryFormSet, extra=3, max_num=3
 )

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import formset_factory

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -1,14 +1,8 @@
 from itertools import chain
 
+from wagtail.core.blocks import ListBlock, StreamBlock, StructBlock
+from wagtail.core.fields import StreamField
 from wagtailinventory.models import PageBlock
-
-
-try:
-    from wagtail.core.blocks import ListBlock, StreamBlock, StructBlock
-    from wagtail.core.fields import StreamField  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.blocks import ListBlock, StreamBlock, StructBlock
-    from wagtail.wagtailcore.fields import StreamField
 
 
 def get_block_name(block):

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -1,5 +1,8 @@
 from itertools import chain
 
+from wagtailinventory.models import PageBlock
+
+
 try:
     from wagtail.core.blocks import ListBlock, StreamBlock, StructBlock
     from wagtail.core.fields import StreamField  # pragma: no cover
@@ -7,11 +10,9 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.blocks import ListBlock, StreamBlock, StructBlock
     from wagtail.wagtailcore.fields import StreamField
 
-from wagtailinventory.models import PageBlock
-
 
 def get_block_name(block):
-    return block.__module__ + '.' + block.__class__.__name__
+    return block.__module__ + "." + block.__class__.__name__
 
 
 def get_page_blocks(page):
@@ -28,13 +29,13 @@ def get_page_blocks(page):
 
 
 def get_field_blocks(value):
-    block = getattr(value, 'block', None)
+    block = getattr(value, "block", None)
     blocks = [block] if block else []
 
     if isinstance(value, list):
         child_blocks = value
     if isinstance(block, StructBlock):
-        if hasattr(value, 'bound_blocks'):
+        if hasattr(value, "bound_blocks"):
             child_blocks = value.bound_blocks.values()
         else:
             child_blocks = [value.value]

--- a/wagtailinventory/management/commands/block_inventory.py
+++ b/wagtailinventory/management/commands/block_inventory.py
@@ -1,16 +1,11 @@
 from django.core.management import BaseCommand
 
 from tqdm import tqdm
+from wagtail.core.models import Page
 from wagtailinventory.helpers import (
     create_page_inventory,
     delete_page_inventory,
 )
-
-
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
 
 
 class Command(BaseCommand):

--- a/wagtailinventory/management/commands/block_inventory.py
+++ b/wagtailinventory/management/commands/block_inventory.py
@@ -1,14 +1,16 @@
 from django.core.management import BaseCommand
+
 from tqdm import tqdm
+from wagtailinventory.helpers import (
+    create_page_inventory,
+    delete_page_inventory,
+)
+
 
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
-
-from wagtailinventory.helpers import (
-    create_page_inventory, delete_page_inventory
-)
 
 
 class Command(BaseCommand):
@@ -17,7 +19,7 @@ class Command(BaseCommand):
 
         pages = Page.objects.all()
 
-        if options.get('verbosity'):  # pragma: no cover
+        if options.get("verbosity"):  # pragma: no cover
             pages = tqdm(pages)
 
         for page in pages:

--- a/wagtailinventory/migrations/0001_initial.py
+++ b/wagtailinventory/migrations/0001_initial.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import django.db.models.deletion
 

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
+
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
@@ -11,9 +12,10 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
 
 @python_2_unicode_compatible
 class PageBlock(models.Model):
-    page = models.ForeignKey(Page, related_name='page_blocks',
-                             on_delete=models.CASCADE)
+    page = models.ForeignKey(
+        Page, related_name="page_blocks", on_delete=models.CASCADE
+    )
     block = models.CharField(max_length=255, db_index=True)
 
     def __str__(self):
-        return '<{}, {}>'.format(self.page, self.block)
+        return "<{}, {}>".format(self.page, self.block)

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -1,11 +1,7 @@
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
+from wagtail.core.models import Page
 
 
 @python_2_unicode_compatible

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import django

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -2,8 +2,6 @@ import os
 
 import django
 
-import wagtail
-
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -21,48 +19,23 @@ DATABASES = {
     },
 }
 
-if wagtail.VERSION >= (2, 0):
-    WAGTAIL_APPS = (
-        "wagtail.contrib.forms",
-        "wagtail.contrib.settings",
-        "wagtail.admin",
-        "wagtail.core",
-        "wagtail.documents",
-        "wagtail.images",
-        "wagtail.sites",
-        "wagtail.users",
-    )
+WAGTAIL_APPS = (
+    "wagtail.contrib.forms",
+    "wagtail.contrib.settings",
+    "wagtail.admin",
+    "wagtail.core",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.sites",
+    "wagtail.users",
+)
 
-    WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
+WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
 
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
-else:
-    WAGTAIL_APPS = (
-        "wagtail.contrib.settings",
-        "wagtail.wagtailadmin",
-        "wagtail.wagtailcore",
-        "wagtail.wagtaildocs",
-        "wagtail.wagtailforms",
-        "wagtail.wagtailimages",
-        "wagtail.wagtailsites",
-        "wagtail.wagtailusers",
-    )
-
-    WAGTAIL_MIDDLEWARE = ("wagtail.wagtailcore.middleware.SiteMiddleware",)
-
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {
-            "WIDGET": "wagtail.wagtailadmin.rich_text.HalloRichTextArea",
-        },
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+    "custom": {"WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"},
+}
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 import django
+
 import wagtail
 
 
@@ -11,124 +12,118 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
-SECRET_KEY = 'not needed'
+SECRET_KEY = "not needed"
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'wagtailinventory.sqlite',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "wagtailinventory.sqlite",
     },
 }
 
 if wagtail.VERSION >= (2, 0):
     WAGTAIL_APPS = (
-        'wagtail.contrib.forms',
-        'wagtail.contrib.settings',
-        'wagtail.admin',
-        'wagtail.core',
-        'wagtail.documents',
-        'wagtail.images',
-        'wagtail.sites',
-        'wagtail.users',
+        "wagtail.contrib.forms",
+        "wagtail.contrib.settings",
+        "wagtail.admin",
+        "wagtail.core",
+        "wagtail.documents",
+        "wagtail.images",
+        "wagtail.sites",
+        "wagtail.users",
     )
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.core.middleware.SiteMiddleware',
-    )
+    WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
 
     WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
         },
     }
 else:
     WAGTAIL_APPS = (
-        'wagtail.contrib.settings',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtailcore',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailforms',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailusers',
+        "wagtail.contrib.settings",
+        "wagtail.wagtailadmin",
+        "wagtail.wagtailcore",
+        "wagtail.wagtaildocs",
+        "wagtail.wagtailforms",
+        "wagtail.wagtailimages",
+        "wagtail.wagtailsites",
+        "wagtail.wagtailusers",
     )
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
+    WAGTAIL_MIDDLEWARE = ("wagtail.wagtailcore.middleware.SiteMiddleware",)
 
     WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
+        "default": {
+            "WIDGET": "wagtail.wagtailadmin.rich_text.HalloRichTextArea",
         },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
         },
     }
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.common.CommonMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ) + WAGTAIL_MIDDLEWARE
 else:
     MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.common.CommonMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ) + WAGTAIL_MIDDLEWARE
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.messages',
-    'django.contrib.sessions',
-    'django.contrib.staticfiles',
-
-    'taggit',
-) + WAGTAIL_APPS + (
-    'wagtailinventory',
-    'wagtailinventory.tests.testapp',
+    (
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.messages",
+        "django.contrib.sessions",
+        "django.contrib.staticfiles",
+        "taggit",
+    )
+    + WAGTAIL_APPS
+    + ("wagtailinventory", "wagtailinventory.tests.testapp",)
 )
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_URL = "/static/"
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MEDIA_URL = "/media/"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.request',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
             ],
-            'debug': True,
+            "debug": True,
         },
     },
 ]
 
-WAGTAIL_SITE_NAME = 'Test Site'
+WAGTAIL_SITE_NAME = "Test Site"
 
-ROOT_URLCONF = 'wagtailinventory.tests.urls'
+ROOT_URLCONF = "wagtailinventory.tests.urls"

--- a/wagtailinventory/tests/test_forms.py
+++ b/wagtailinventory/tests/test_forms.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.test import TestCase
 

--- a/wagtailinventory/tests/test_forms.py
+++ b/wagtailinventory/tests/test_forms.py
@@ -3,39 +3,40 @@ from __future__ import absolute_import, unicode_literals
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.test import TestCase
 
+from wagtailinventory.forms import PageBlockQueryForm
+from wagtailinventory.models import PageBlock
+
+
 try:
     from wagtail.core.models import Page, Site
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page, Site
 
-from wagtailinventory.forms import PageBlockQueryForm
-from wagtailinventory.models import PageBlock
-
 
 class TestPageBlockQueryForm(TestCase):
     def test_no_page_blocks_in_database_form_has_blank_choice(self):
         form = PageBlockQueryForm()
-        form_choices = form.fields['block'].choices
+        form_choices = form.fields["block"].choices
 
         self.assertEqual(len(form_choices), 1)
         self.assertEqual(form_choices, BLANK_CHOICE_DASH)
 
     def test_form_choices_alphabetized(self):
         root_page = Site.objects.get(is_default_site=True).root_page
-        page = Page(title='Title', slug='title')
+        page = Page(title="Title", slug="title")
         root_page.add_child(instance=page)
 
         for block in (
-            'blocks.mango',
-            'blocks.apple',
-            'blocks.banana',
+            "blocks.mango",
+            "blocks.apple",
+            "blocks.banana",
         ):
             PageBlock.objects.create(page=page, block=block)
 
         form = PageBlockQueryForm()
-        form_choices = form.fields['block'].choices
+        form_choices = form.fields["block"].choices
 
         self.assertEqual(len(form_choices), 4)
-        self.assertEqual(form_choices[1][0], 'blocks.apple')
-        self.assertEqual(form_choices[2][0], 'blocks.banana')
-        self.assertEqual(form_choices[3][0], 'blocks.mango')
+        self.assertEqual(form_choices[1][0], "blocks.apple")
+        self.assertEqual(form_choices[2][0], "blocks.banana")
+        self.assertEqual(form_choices[3][0], "blocks.mango")

--- a/wagtailinventory/tests/test_forms.py
+++ b/wagtailinventory/tests/test_forms.py
@@ -1,14 +1,9 @@
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.test import TestCase
 
+from wagtail.core.models import Page, Site
 from wagtailinventory.forms import PageBlockQueryForm
 from wagtailinventory.models import PageBlock
-
-
-try:
-    from wagtail.core.models import Page, Site
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page, Site
 
 
 class TestPageBlockQueryForm(TestCase):

--- a/wagtailinventory/tests/test_helpers.py
+++ b/wagtailinventory/tests/test_helpers.py
@@ -1,19 +1,10 @@
 from django.test import TestCase
 
-import wagtail
+from wagtail.core.models import Page
 from wagtailinventory.helpers import get_page_blocks
 
 
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
-
-
-if wagtail.VERSION[0] > 1:
-    CORE_BLOCKS = "wagtail.core.blocks"
-else:  # pragma: no cover' fallback for Wagtail <2.0
-    CORE_BLOCKS = "wagtail.wagtailcore.blocks"
+CORE_BLOCKS = "wagtail.core.blocks"
 
 
 class TestGetPageBlocks(TestCase):

--- a/wagtailinventory/tests/test_helpers.py
+++ b/wagtailinventory/tests/test_helpers.py
@@ -1,62 +1,62 @@
 from django.test import TestCase
 
 import wagtail
+from wagtailinventory.helpers import get_page_blocks
+
 
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
 
-from wagtailinventory.helpers import get_page_blocks
-
 
 if wagtail.VERSION[0] > 1:
-    CORE_BLOCKS = 'wagtail.core.blocks'
+    CORE_BLOCKS = "wagtail.core.blocks"
 else:  # pragma: no cover' fallback for Wagtail <2.0
-    CORE_BLOCKS = 'wagtail.wagtailcore.blocks'
+    CORE_BLOCKS = "wagtail.wagtailcore.blocks"
 
 
 class TestGetPageBlocks(TestCase):
-    fixtures = ['test_blocks.json']
+    fixtures = ["test_blocks.json"]
 
     def test_page_with_no_streamfields_returns_empty_list(self):
-        page = Page.objects.get(slug='no-streamfields-page')
+        page = Page.objects.get(slug="no-streamfields-page")
         self.assertEqual(get_page_blocks(page), [])
 
     def test_empty_streamfield_returns_empty_list(self):
-        page = Page.objects.get(slug='single-streamfield-page-no-content')
+        page = Page.objects.get(slug="single-streamfield-page-no-content")
         self.assertEqual(get_page_blocks(page), [])
 
     def test_streamfield_with_single_block(self):
-        page = Page.objects.get(slug='single-streamfield-page-content')
+        page = Page.objects.get(slug="single-streamfield-page-content")
         self.assertEqual(
             get_page_blocks(page),
             [
-                CORE_BLOCKS + '.field_block.CharBlock',
-                'wagtailinventory.tests.testapp.blocks.Atom',
+                CORE_BLOCKS + ".field_block.CharBlock",
+                "wagtailinventory.tests.testapp.blocks.Atom",
             ],
         )
 
     def test_multiple_streamfields(self):
-        page = Page.objects.get(slug='multiple-streamfields-page')
+        page = Page.objects.get(slug="multiple-streamfields-page")
         self.assertEqual(
             get_page_blocks(page),
             [
-                CORE_BLOCKS + '.field_block.CharBlock',
-                CORE_BLOCKS + '.list_block.ListBlock',
-                'wagtailinventory.tests.testapp.blocks.Atom',
-                'wagtailinventory.tests.testapp.blocks.Molecule',
-                'wagtailinventory.tests.testapp.blocks.Organism',
-            ]
+                CORE_BLOCKS + ".field_block.CharBlock",
+                CORE_BLOCKS + ".list_block.ListBlock",
+                "wagtailinventory.tests.testapp.blocks.Atom",
+                "wagtailinventory.tests.testapp.blocks.Molecule",
+                "wagtailinventory.tests.testapp.blocks.Organism",
+            ],
         )
 
     def test_nested_streamblocks(self):
-        page = Page.objects.get(slug='nested-streamblock-page')
+        page = Page.objects.get(slug="nested-streamblock-page")
         self.assertEqual(
             get_page_blocks(page),
             [
-                CORE_BLOCKS + '.field_block.CharBlock',
-                CORE_BLOCKS + '.stream_block.StreamBlock',
-                'wagtailinventory.tests.testapp.blocks.Atom',
-            ]
+                CORE_BLOCKS + ".field_block.CharBlock",
+                CORE_BLOCKS + ".stream_block.StreamBlock",
+                "wagtailinventory.tests.testapp.blocks.Atom",
+            ],
         )

--- a/wagtailinventory/tests/test_models.py
+++ b/wagtailinventory/tests/test_models.py
@@ -1,12 +1,7 @@
 from django.test import TestCase
 
+from wagtail.core.models import Page
 from wagtailinventory.models import PageBlock
-
-
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
 
 
 class TestPageBlock(TestCase):

--- a/wagtailinventory/tests/test_models.py
+++ b/wagtailinventory/tests/test_models.py
@@ -2,18 +2,18 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
+from wagtailinventory.models import PageBlock
+
+
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
 
-from wagtailinventory.models import PageBlock
-
 
 class TestPageBlock(TestCase):
     def test_page_str(self):
         page_block = PageBlock(
-            page=Page(title='Title', slug='title'),
-            block='path.to.block'
+            page=Page(title="Title", slug="title"), block="path.to.block"
         )
-        self.assertEqual(str(page_block), '<Title, path.to.block>')
+        self.assertEqual(str(page_block), "<Title, path.to.block>")

--- a/wagtailinventory/tests/test_models.py
+++ b/wagtailinventory/tests/test_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.test import TestCase
 
 from wagtailinventory.models import PageBlock

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -3,25 +3,26 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.six.moves.urllib.parse import urlencode
 
+from wagtail.tests.utils import WagtailTestUtils
+
+
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
 
-from wagtail.tests.utils import WagtailTestUtils
-
 
 class SearchViewTests(WagtailTestUtils, TestCase):
-    fixtures = ['test_blocks.json']
+    fixtures = ["test_blocks.json"]
 
     def setUp(self):
         self.login()
 
     def get(self, params=None):
-        path = reverse('wagtailinventory:search')
+        path = reverse("wagtailinventory:search")
 
         if params:
-            path += '?' + urlencode(params)
+            path += "?" + urlencode(params)
 
         return self.client.get(path)
 
@@ -29,29 +30,33 @@ class SearchViewTests(WagtailTestUtils, TestCase):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.context['pages'].object_list,
-            list(Page.objects.order_by('title'))
+            response.context["pages"].object_list,
+            list(Page.objects.order_by("title")),
         )
 
     def test_get_bad_formset_query_returns_400(self):
-        response = self.get({
-            'form-TOTAL_FORMS': 1,
-            'form-INITIAL_FORMS': 0,
-            'form-0-has': 'invalid',
-        })
+        response = self.get(
+            {
+                "form-TOTAL_FORMS": 1,
+                "form-INITIAL_FORMS": 0,
+                "form-0-has": "invalid",
+            }
+        )
         self.assertEqual(response.status_code, 400)
 
     def test_valid_query_returns_200_and_only_appropriate_pages(self):
-        call_command('block_inventory', verbosity=0)
+        call_command("block_inventory", verbosity=0)
 
-        response = self.get({
-            'form-TOTAL_FORMS': 1,
-            'form-INITIAL_FORMS': 0,
-            'form-0-has': 'includes',
-            'form-0-block': 'wagtailinventory.tests.testapp.blocks.Organism',
-        })
+        response = self.get(
+            {
+                "form-TOTAL_FORMS": 1,
+                "form-INITIAL_FORMS": 0,
+                "form-0-has": "includes",
+                "form-0-block": "wagtailinventory.tests.testapp.blocks.Organism",  # noqa
+            }
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.context['pages'].object_list,
-            [Page.objects.get(slug='multiple-streamfields-page')]
+            response.context["pages"].object_list,
+            [Page.objects.get(slug="multiple-streamfields-page")],
         )

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -3,13 +3,8 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.six.moves.urllib.parse import urlencode
 
+from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailTestUtils
-
-
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
 
 
 class SearchViewTests(WagtailTestUtils, TestCase):

--- a/wagtailinventory/tests/testapp/blocks.py
+++ b/wagtailinventory/tests/testapp/blocks.py
@@ -1,7 +1,4 @@
-try:
-    from wagtail.core import blocks
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore import blocks
+from wagtail.core import blocks
 
 
 class Atom(blocks.StructBlock):

--- a/wagtailinventory/tests/testapp/migrations/0001_initial.py
+++ b/wagtailinventory/tests/testapp/migrations/0001_initial.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import django.db.models.deletion
 

--- a/wagtailinventory/tests/testapp/migrations/0001_initial.py
+++ b/wagtailinventory/tests/testapp/migrations/0001_initial.py
@@ -2,12 +2,8 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
-try:
-    from wagtail.core import blocks as core_blocks
-    from wagtail.core import fields as core_fields  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore import blocks as core_blocks
-    from wagtail.wagtailcore import fields as core_fields
+from wagtail.core import blocks as core_blocks
+from wagtail.core import fields as core_fields  # pragma: no cover
 
 
 class Migration(migrations.Migration):

--- a/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
+++ b/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import django.db.models.deletion
 

--- a/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
+++ b/wagtailinventory/tests/testapp/migrations/0002_nested_stream_block_page.py
@@ -2,12 +2,8 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
-try:
-    from wagtail.core import blocks as core_blocks
-    from wagtail.core import fields as core_fields  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore import blocks as core_blocks
-    from wagtail.wagtailcore import fields as core_fields
+from wagtail.core import blocks as core_blocks
+from wagtail.core import fields as core_fields  # pragma: no cover
 
 
 class Migration(migrations.Migration):

--- a/wagtailinventory/tests/testapp/migrations/0003_single_content_block_optional.py
+++ b/wagtailinventory/tests/testapp/migrations/0003_single_content_block_optional.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.db import migrations
 
-try:
-    from wagtail.core import blocks as core_blocks
-    from wagtail.core import fields as core_fields  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore import blocks as core_blocks
-    from wagtail.wagtailcore import fields as core_fields
+from wagtail.core import blocks as core_blocks
+from wagtail.core import fields as core_fields  # pragma: no cover
 
 
 class Migration(migrations.Migration):

--- a/wagtailinventory/tests/testapp/migrations/0003_single_content_block_optional.py
+++ b/wagtailinventory/tests/testapp/migrations/0003_single_content_block_optional.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations
 
 try:

--- a/wagtailinventory/tests/testapp/models.py
+++ b/wagtailinventory/tests/testapp/models.py
@@ -1,5 +1,8 @@
 from django.db import models
 
+from wagtailinventory.tests.testapp import blocks
+
+
 try:
     from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
     from wagtail.core import blocks as wagtail_blocks  # pragma: no cover
@@ -11,55 +14,67 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.fields import StreamField
     from wagtail.wagtailcore.models import Page
 
-from wagtailinventory.tests.testapp import blocks
-
 
 class NoStreamFieldsPage(Page):
     content = models.TextField()
 
     content_panels = Page.content_panels + [
-        FieldPanel('content'),
+        FieldPanel("content"),
     ]
 
 
 class SingleStreamFieldPage(Page):
-    content = StreamField([
-        ('atom', blocks.Atom()),
-        ('molecule', blocks.Molecule()),
-        ('organism', blocks.Organism()),
-    ], blank=True)
+    content = StreamField(
+        [
+            ("atom", blocks.Atom()),
+            ("molecule", blocks.Molecule()),
+            ("organism", blocks.Organism()),
+        ],
+        blank=True,
+    )
 
     content_panels = Page.content_panels + [
-        StreamFieldPanel('content'),
+        StreamFieldPanel("content"),
     ]
 
 
 class MultipleStreamFieldsPage(Page):
-    first = StreamField([
-        ('atom', blocks.Atom()),
-        ('molecule', blocks.Molecule()),
-        ('organism', blocks.Organism()),
-    ])
-    second = StreamField([
-        ('atom', blocks.Atom()),
-        ('molecule', blocks.Molecule()),
-        ('organism', blocks.Organism()),
-    ])
+    first = StreamField(
+        [
+            ("atom", blocks.Atom()),
+            ("molecule", blocks.Molecule()),
+            ("organism", blocks.Organism()),
+        ]
+    )
+    second = StreamField(
+        [
+            ("atom", blocks.Atom()),
+            ("molecule", blocks.Molecule()),
+            ("organism", blocks.Organism()),
+        ]
+    )
 
     content_panels = Page.content_panels + [
-        StreamFieldPanel('first'),
-        StreamFieldPanel('second'),
+        StreamFieldPanel("first"),
+        StreamFieldPanel("second"),
     ]
 
 
 class NestedStreamBlockPage(Page):
-    content = StreamField([
-        ('streamblock', wagtail_blocks.StreamBlock([
-            ('text', wagtail_blocks.CharBlock()),
-            ('atom', blocks.Atom()),
-        ])),
-    ])
+    content = StreamField(
+        [
+            (
+                "streamblock",
+                wagtail_blocks.StreamBlock(
+                    [
+                        ("text", wagtail_blocks.CharBlock()),
+                        ("atom", blocks.Atom()),
+                    ]
+                ),
+            ),
+        ]
+    )
 
     content_panels = Page.content_panels + [
-        StreamFieldPanel('content'),
+        StreamFieldPanel("content"),
     ]

--- a/wagtailinventory/tests/testapp/models.py
+++ b/wagtailinventory/tests/testapp/models.py
@@ -1,18 +1,10 @@
 from django.db import models
 
+from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
+from wagtail.core import blocks as wagtail_blocks
+from wagtail.core.fields import StreamField
+from wagtail.core.models import Page
 from wagtailinventory.tests.testapp import blocks
-
-
-try:
-    from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
-    from wagtail.core import blocks as wagtail_blocks  # pragma: no cover
-    from wagtail.core.fields import StreamField  # pragma: no cover
-    from wagtail.core.models import Page  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
-    from wagtail.wagtailcore import blocks as wagtail_blocks
-    from wagtail.wagtailcore.fields import StreamField
-    from wagtail.wagtailcore.models import Page
 
 
 class NoStreamFieldsPage(Page):

--- a/wagtailinventory/tests/urls.py
+++ b/wagtailinventory/tests/urls.py
@@ -13,9 +13,9 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'', include(wagtailcore_urls)),
+    url(r"^admin/", include(wagtailadmin_urls)),
+    url(r"^documents/", include(wagtaildocs_urls)),
+    url(r"", include(wagtailcore_urls)),
 ]
 
 
@@ -25,6 +25,5 @@ if settings.DEBUG:
 
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(
-        settings.MEDIA_URL,
-        document_root=settings.MEDIA_ROOT
+        settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
     )

--- a/wagtailinventory/tests/urls.py
+++ b/wagtailinventory/tests/urls.py
@@ -1,15 +1,20 @@
 from django.conf import settings
-from django.conf.urls import include, url
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtailcore_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 
+try:
+    from django.urls import include, re_path
+except ImportError:
+    from django.conf.urls import include, url as re_path
+
+
 urlpatterns = [
-    url(r"^admin/", include(wagtailadmin_urls)),
-    url(r"^documents/", include(wagtaildocs_urls)),
-    url(r"", include(wagtailcore_urls)),
+    re_path(r"^admin/", include(wagtailadmin_urls)),
+    re_path(r"^documents/", include(wagtaildocs_urls)),
+    re_path(r"", include(wagtailcore_urls)),
 ]
 
 

--- a/wagtailinventory/tests/urls.py
+++ b/wagtailinventory/tests/urls.py
@@ -1,15 +1,9 @@
 from django.conf import settings
 from django.conf.urls import include, url
 
-
-try:
-    from wagtail.admin import urls as wagtailadmin_urls
-    from wagtail.core import urls as wagtailcore_urls  # pragma: no cover
-    from wagtail.documents import urls as wagtaildocs_urls  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
-    from wagtail.wagtailcore import urls as wagtailcore_urls
-    from wagtail.wagtaildocs import urls as wagtaildocs_urls
+from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.core import urls as wagtailcore_urls
+from wagtail.documents import urls as wagtaildocs_urls
 
 
 urlpatterns = [

--- a/wagtailinventory/urls.py
+++ b/wagtailinventory/urls.py
@@ -1,11 +1,15 @@
-from django.conf.urls import url
-
 from wagtailinventory.views import SearchView
+
+
+try:
+    from django.urls import re_path
+except ImportError:
+    from django.conf.urls import url as re_path
 
 
 app_name = "wagtailinventory"
 
 
 urlpatterns = [
-    url(r"^$", SearchView.as_view(), name="search"),
+    re_path(r"^$", SearchView.as_view(), name="search"),
 ]

--- a/wagtailinventory/urls.py
+++ b/wagtailinventory/urls.py
@@ -3,9 +3,9 @@ from django.conf.urls import url
 from wagtailinventory.views import SearchView
 
 
-app_name = 'wagtailinventory'
+app_name = "wagtailinventory"
 
 
 urlpatterns = [
-    url(r'^$', SearchView.as_view(), name='search'),
+    url(r"^$", SearchView.as_view(), name="search"),
 ]

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -3,13 +3,8 @@ from django.shortcuts import render
 from django.views.generic import View
 
 import wagtail
+from wagtail.core.models import Page
 from wagtailinventory.forms import PageBlockQueryFormSet
-
-
-try:
-    from wagtail.core.models import Page
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
 
 
 class SearchView(View):

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.http import HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.generic import View

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -5,44 +5,45 @@ from django.shortcuts import render
 from django.views.generic import View
 
 import wagtail
+from wagtailinventory.forms import PageBlockQueryFormSet
+
 
 try:
     from wagtail.core.models import Page
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Page
 
-from wagtailinventory.forms import PageBlockQueryFormSet
-
 
 class SearchView(View):
-    template_name = 'wagtailinventory/search.html'
+    template_name = "wagtailinventory/search.html"
 
     def get(self, request):
         if len(request.GET) > 1:
             formset = PageBlockQueryFormSet(request.GET)
             if not formset.is_valid():
-                return HttpResponseBadRequest('invalid query')
+                return HttpResponseBadRequest("invalid query")
 
             queryset = formset.get_query()
         else:
             formset = PageBlockQueryFormSet()
             queryset = Page.objects.all()
 
-        queryset = queryset.order_by('title')
+        queryset = queryset.order_by("title")
 
         # https://docs.wagtail.io/en/latest/releases/2.5.html#changes-to-admin-pagination-helpers
         if wagtail.VERSION < (2, 5):
             from wagtail.utils.pagination import paginate
+
             paginator, pages = paginate(request, queryset)
         else:  # pragma: no cover
             from django.core.paginator import Paginator
+
             paginator = Paginator(queryset, per_page=20)
-            pages = paginator.get_page(request.GET.get('p'))
+            pages = paginator.get_page(request.GET.get("p"))
 
         for page in pages:
             page.can_choose = True
 
-        return render(request, self.template_name, {
-            'formset': formset,
-            'pages': pages,
-        })
+        return render(
+            request, self.template_name, {"formset": formset, "pages": pages}
+        )

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -2,6 +2,14 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
+from wagtailinventory import urls
+from wagtailinventory.helpers import (
+    create_page_inventory,
+    delete_page_inventory,
+    update_page_inventory,
+)
+
+
 try:
     from django.urls import reverse
 except ImportError:  # pragma: no cover; fallback for Django <1.10
@@ -14,39 +22,34 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailadmin.menu import MenuItem
     from wagtail.wagtailcore import hooks
 
-from wagtailinventory import urls
-from wagtailinventory.helpers import (
-    create_page_inventory, delete_page_inventory, update_page_inventory
-)
 
-
-@hooks.register('after_create_page')
+@hooks.register("after_create_page")
 def do_after_page_create(request, page):
     create_page_inventory(page)
 
 
-@hooks.register('after_edit_page')
+@hooks.register("after_edit_page")
 def do_after_page_edit(request, page):
     update_page_inventory(page)
 
 
-@hooks.register('after_delete_page')
+@hooks.register("after_delete_page")
 def do_after_page_dete(request, page):
     delete_page_inventory(page)
 
 
-@hooks.register('register_admin_urls')
+@hooks.register("register_admin_urls")
 def register_inventory_urls():
     return [
-        url(r'^inventory/', include(urls, namespace='wagtailinventory')),
+        url(r"^inventory/", include(urls, namespace="wagtailinventory")),
     ]
 
 
-@hooks.register('register_settings_menu_item')
+@hooks.register("register_settings_menu_item")
 def register_inventory_menu_item():
     return MenuItem(
-        'Block Inventory',
-        reverse('wagtailinventory:search'),
-        classnames='icon icon-placeholder',
-        order=11000
+        "Block Inventory",
+        reverse("wagtailinventory:search"),
+        classnames="icon icon-placeholder",
+        order=11000,
     )

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf.urls import include, url
 
 from wagtailinventory import urls


### PR DESCRIPTION
## Additions
Support for Django 2.2 imports
Add black to tox

## Removals
Support for Wagtail 1.13 in tox and travis
`from __future__ import absolute_import, unicode_literals`

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests