### PR TITLE
Remove the Django requirement from this application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-wag23
+    - env: TOXENV=py36-dj111-wag23
       python: 3.6
-    - env: TOXENV=py36-wag28
+    - env: TOXENV=py36-dj22-wag23
       python: 3.6
-    - env: TOXENV=py38-wag28
+    - env: TOXENV=py36-dj22-wag29
+      python: 3.6
+    - env: TOXENV=py38-dj22-wag29
       python: 3.8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,11 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-dj111-wag23
+    - env: TOXENV=py36-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag23
+    - env: TOXENV=py36-wag28
       python: 3.6
-    - env: TOXENV=py36-dj20-wag28
-      python: 3.6
-    - env: TOXENV=py36-dj22-wag28
-      python: 3.6
-    - env: TOXENV=py38-dj20-wag28
-      python: 3.8
-    - env: TOXENV=py38-dj22-wag28
+    - env: TOXENV=py38-wag28
       python: 3.8
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,6 @@ Compatibility
 This code has been tested for compatibility with:
 
 * Python 3.6, 3.8
-* Django 1.11, 2.0, 2.2
 * Wagtail 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ Compatibility
 This code has been tested for compatibility with:
 
 * Python 3.6, 3.8
-* Wagtail 2.3, 2.8
+* Django 1.11, 2.2
+* Wagtail 2.3, 2.9
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "Django>=1.11,<2.3",
     "tqdm==4.15.0",
     "wagtail>=2.3,<2.9",
 ]
@@ -36,10 +35,7 @@ setup(
     extras_require={"testing": testing_extras,},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
-        "Framework :: Django :: 2.2",
+        "Framework :: Wagtail :: 3",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm==4.15.0",
-    "wagtail>=2.3,<2.9",
+    "wagtail>=2.3,<2.10",
 ]
 
 
@@ -35,7 +35,8 @@ setup(
     extras_require={"testing": testing_extras,},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Wagtail :: 3",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist=True
 envlist=lint,
-        py36-wag23,
-        py{36,38}-wag28,
+        py36-dj111-wag23,
+        py{36,38}-dj22-wag29,
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,8 +18,10 @@ basepython=
 
 deps=
     mock>=1.0.0
+    dj111: Django>=1.11,<1.12
+    dj22:  Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
-    wag28: wagtail>=2.8,<2.9
+    wag29: wagtail>=2.9,<2.10
 
 [testenv:lint]
 recreate=False

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist=lint,
-        py36-dj111-wag23,
+        py{36}-dj{111,22}-wag23,
         py{36,38}-dj22-wag29,
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist=True
 envlist=lint,
-        py36-dj{111,20}-wag23,
-        py{36,38}-dj{20,22}-wag28,
+        py36-wag23,
+        py{36,38}-wag28,
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,9 +18,6 @@ basepython=
 
 deps=
     mock>=1.0.0
-    dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
-    dj22: Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist=True
 envlist=lint,
-        py{36}-dj{111,22}-wag23,
-        py{36,38}-dj22-wag29,
+        py{36}-dj{111,22}-wag{23},
+        py{36,38}-dj{22}-wag{29},
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -1,10 +1,8 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from wagtail.core.models import Page
 
 
-@python_2_unicode_compatible
 class PageBlock(models.Model):
     page = models.ForeignKey(
         Page, related_name="page_blocks", on_delete=models.CASCADE

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -1,8 +1,9 @@
+from urllib.parse import urlencode
+
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 
-from six.moves.urllib.parse import urlencode
 from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -1,8 +1,8 @@
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.six.moves.urllib.parse import urlencode
 
+from six.moves.urllib.parse import urlencode
 from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailTestUtils
 


### PR DESCRIPTION
We should probably only pin Wagtail in this application, and support
the version range for Django that our Wagtail version specifies.