### PR TITLE
Make sure GitHub release action only runs once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Publish to PyPI
-on: [release]
+on: 
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
The GitHub release action was running for three different GitHub release events: created, published, released. This ensures it only runs once, on published.