### PR TITLE
Swap Travis badge for Github Actions Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://travis-ci.org/cfpb/wagtail-inventory.svg?branch=main
+.. image:: https://github.com/cfpb/wagtail-inventory/workflows/test/badge.svg
   :alt: Build Status
   :target: https://travis-ci.org/cfpb/wagtail-inventory
 .. image:: https://coveralls.io/repos/github/cfpb/wagtail-sharing/badge.svg?branch=main


### PR DESCRIPTION
Swaps our build badge to use the Github Actions Build Badge.

## Changes

- Travis CI Badge to Github Actions badge