### PR TITLE
Add support for wagtail 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,22 +34,34 @@ jobs:
         toxenv:
             - py36-dj22-wag27
             - py36-dj22-wag210
+            - py36-dj22-wag211
             - py36-dj31-wag210
+            - py36-dj31-wag211
             - py38-dj22-wag27
             - py38-dj22-wag210
+            - py38-dj22-wag211
             - py38-dj31-wag210
+            - py38-dj31-wag211
         include:
           - toxenv: py36-dj22-wag27
             python-version: 3.6
           - toxenv: py36-dj22-wag210
             python-version: 3.6
+          - toxenv: py36-dj22-wag211
+            python-version: 3.6
           - toxenv: py36-dj31-wag210
+            python-version: 3.6
+          - toxenv: py36-dj31-wag211
             python-version: 3.6
           - toxenv: py38-dj22-wag27
             python-version: 3.8
           - toxenv: py38-dj22-wag210
             python-version: 3.8
+          - toxenv: py38-dj22-wag211
+            python-version: 3.8
           - toxenv: py38-dj31-wag210
+            python-version: 3.8
+          - toxenv: py38-dj31-wag211
             python-version: 3.8
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm==4.15.0",
-    "wagtail>=2.7",
+    "wagtail>=2.7,<2.12",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm==4.15.0",
-    "wagtail>=2.7,<2.11",
+    "wagtail>=2.7",
 ]
 
 
@@ -14,7 +14,6 @@ setup_requires = [
 
 testing_extras = [
     "coverage>=3.7.0",
-    "mock>=1.0.0",
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22,31}-wag{27,210}
+    py{36,38}-dj{22,31}-wag{27,210,211}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,11 +18,11 @@ basepython=
     py38: python3.8
 
 deps=
-    mock>=1.0.0
     dj22:  Django>=2.2,<2.3
     dj31:  Django>=3.1,<3.2
     wag27: wagtail>=2.7,<2.8
     wag210: wagtail>=2.10,<2.11
+    wag211: wagtail>=2.11,<2.12
 
 [testenv:lint]
 basepython=python3.6

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -53,7 +53,10 @@ INSTALLED_APPS = (
         "taggit",
     )
     + WAGTAIL_APPS
-    + ("wagtailinventory", "wagtailinventory.tests.testapp",)
+    + (
+        "wagtailinventory",
+        "wagtailinventory.tests.testapp",
+    )
 )
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")


### PR DESCRIPTION
Add support for Wagtail 2.11

https://docs.wagtail.io/en/stable/releases/2.11.html

## Additions

## Removals

- Remove the upper bound for wagtail version in 2.11. This aligns with the recommendation in the [python.org documentation](https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires)
  - `It is not considered best practice to use install_requires to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.`
  - I feel strongly about this change. Without it, each Wagtail update forces me to either disable wagtail-inventory or wait for wagtail-inventory to permit the new version.
- Remove mock from the test stack. Mock is part of the standard library in python 3, and this repo no longer supports python 2. In addition, it doesn't look like any tests are making use of mock.

## Changes

- Update tox and github actions to support 2.11
- Misc: fix linting failure in tests/settings.py

## Testing

1. All existing tests pass

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
