### PR TITLE
Upgrade wagtail support to anything in this major version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,23 +33,23 @@ jobs:
       matrix:
         toxenv:
             - py36-dj22-wag27
-            - py36-dj22-wag210
-            - py36-dj31-wag210
+            - py36-dj22-waglatest
+            - py36-dj31-waglatest
             - py38-dj22-wag27
-            - py38-dj22-wag210
-            - py38-dj31-wag210
+            - py38-dj22-waglatest
+            - py38-dj31-waglatest
         include:
           - toxenv: py36-dj22-wag27
             python-version: 3.6
-          - toxenv: py36-dj22-wag210
+          - toxenv: py36-dj22-waglatest
             python-version: 3.6
-          - toxenv: py36-dj31-wag210
+          - toxenv: py36-dj31-waglatest
             python-version: 3.6
           - toxenv: py38-dj22-wag27
             python-version: 3.8
-          - toxenv: py38-dj22-wag210
+          - toxenv: py38-dj22-waglatest
             python-version: 3.8
-          - toxenv: py38-dj31-wag210
+          - toxenv: py38-dj31-waglatest
             python-version: 3.8
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm==4.15.0",
-    "wagtail>=2.7,<2.11",
+    "wagtail>=2.7,<3",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22,31}-wag{27,210}
+    py{36,38}-dj{22,31}-wag{27,latest}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -22,7 +22,7 @@ deps=
     dj22:  Django>=2.2,<2.3
     dj31:  Django>=3.1,<3.2
     wag27: wagtail>=2.7,<2.8
-    wag210: wagtail>=2.10,<2.11
+    waglatest: wagtail>=2.10,<3
 
 [testenv:lint]
 basepython=python3.6

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -53,7 +53,10 @@ INSTALLED_APPS = (
         "taggit",
     )
     + WAGTAIL_APPS
-    + ("wagtailinventory", "wagtailinventory.tests.testapp",)
+    + (
+        "wagtailinventory",
+        "wagtailinventory.tests.testapp",
+    )
 )
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")


### PR DESCRIPTION
Configures our testing suite to test against the latest release of wagtail instead of a hard set maximum.

## Changes

- wagtail < 2.11 -> wagtail < 3

## Notes

- This is to align with our new goal of supporting new releases of wagtail based on tests passing, rather than manually confirming the library works. 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
