### PR TITLE
add chevron icon to select dropdown

### DIFF
--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -15,13 +15,11 @@ class PageBlockQueryForm(forms.Form):
         choices=(),
         required=False,
         label="Block type",
-        widget=forms.Select(attrs={"style": "width: 50%"}),
     )
 
     has = forms.ChoiceField(
         choices=((c, c) for c in (INCLUDES_BLOCK, EXCLUDES_BLOCK)),
         label=None,
-        widget=forms.Select(attrs={"style": "width: 100px"}),
     )
 
     def __init__(self, *args, **kwargs):

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -12,10 +12,16 @@
 <form class="nice-padding" action="{% url 'wagtailinventory:search' %}">
 	{{ formset.management_form }}
   {% for form in formset %}
-    <div>
-      {{ form.has }}
-      {{ form.block }}
-    </div>
+      <div class="choice_field" style="margin-bottom: 5px">
+          <div class="input" style="width: 175px; display: inline-block">
+              {{ form.has }}
+              <span></span>
+          </div>
+          <div class="input" style="width: 50%; display: inline-block">
+              {{ form.block }}
+              <span></span>
+          </div>
+      </div>
   {% endfor %}
   <input type="submit" value="Find matching pages" style="width: 240px; padding: 10px; margin: 10px 0" />
 </form>


### PR DESCRIPTION
This PR resolves #39.

## Additions

-

## Removals

-

## Changes

- Update select element html structure to integrate with Wagtail's chevron icon
- Move some CSS styles from forms.py to the template to integrate properly with the new html structure

## Testing

1. I ran tox for python 3.6 and the tests passed. I did not modify or create unit tests.

## Screenshots

New:
![image](https://user-images.githubusercontent.com/2699164/104209680-06750e80-5400-11eb-90e0-db488b57ad62.png)

Old:
![image](https://user-images.githubusercontent.com/2699164/104209646-feb56a00-53ff-11eb-9315-ceddb00db127.png)


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
