### PR TITLE
Allow Coveralls to run on forks of this repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,4 +71,4 @@ jobs:
             coveralls
         env: 
           TOXENV: ${{ matrix.toxenv }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub Actions checks fail when run on forks of this repository ([example](https://github.com/cfpb/wagtail-inventory/pull/40/checks?check_run_id=1682697219) from #40) due to missing Coveralls configuration. This PR allows Coveralls to run successfully on forks.

Per the [Coveralls documentation](https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html), typically you need to set the environment variable `COVERALLS_REPO_TOKEN`, which we do on cfpb/wagtail-inventory as a repository secret. But forks don't have that variable defined, which leads to errors like this:

> Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.

The Coveralls docs provide [another way](https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-gotcha) to get this to work, by passing the GitHub token directly, as I'm doing here.

There is a slight downside to this approach, which is that `GITHUB_TOKEN` essentially grants write privilege to Coveralls back to the repository (see https://github.com/coverallsapp/github-action/issues/68). An alternative approach would be to only run Coveralls if `COVERALS_REPO_TOKEN` is defined.