### PR TITLE
Add missing chevron icons to select dropdowns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,4 @@ jobs:
         env: 
           TOXENV: ${{ matrix.toxenv }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.6
 
       - name: Install dependencies
         run: |

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -15,13 +15,11 @@ class PageBlockQueryForm(forms.Form):
         choices=(),
         required=False,
         label="Block type",
-        widget=forms.Select(attrs={"style": "width: 50%"}),
     )
 
     has = forms.ChoiceField(
         choices=((c, c) for c in (INCLUDES_BLOCK, EXCLUDES_BLOCK)),
         label=None,
-        widget=forms.Select(attrs={"style": "width: 100px"}),
     )
 
     def __init__(self, *args, **kwargs):

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -5,6 +5,26 @@
 
 {% block titletag %}{% trans "Block Inventory" %}{% endblock %}
 
+{% block extra_css %}
+<style>
+.wagtail-inventory-select .select {
+    display: inline-block;
+}
+
+.wagtail-inventory-select .field-content {
+    width: 100%;
+}
+
+.wagtail-inventory-select .select-has {
+    width: 175px;
+}
+
+.wagtail-inventory-select .select-block {
+    width: 50%;
+}
+</style>
+{% endblock %}
+
 {% block content %}
 {% trans "Block Inventory" as header_str %}
 {% include "wagtailadmin/shared/header.html" with title=header_str icon="placeholder" %}
@@ -12,9 +32,9 @@
 <form class="nice-padding" action="{% url 'wagtailinventory:search' %}">
 	{{ formset.management_form }}
   {% for form in formset %}
-    <div>
-      {{ form.has }}
-      {{ form.block }}
+    <div class="wagtail-inventory-select">
+      {% include "wagtailadmin/shared/field.html" with field=form.has show_label=False field_classes="select-has" %}
+      {% include "wagtailadmin/shared/field.html" with field=form.block show_label=False field_classes="select-block" %}
     </div>
   {% endfor %}
   <input type="submit" value="Find matching pages" style="width: 240px; padding: 10px; margin: 10px 0" />

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -7,21 +7,24 @@
 
 {% block extra_css %}
 <style>
-.wagtail-inventory-select .select {
-    display: inline-block;
-}
-
-.wagtail-inventory-select .field-content {
-    width: 100%;
-}
-
-.wagtail-inventory-select .select-has {
-    width: 175px;
-}
-
-.wagtail-inventory-select .select-block {
-    width: 50%;
-}
+    form.nice-padding {
+        display: table;
+        box-sizing: border-box;
+        width: 100%;
+    }
+    .wagtail-inventory-select {
+        display: table-row;
+    }
+    .wagtail-inventory-select .select {
+        display: table-cell;
+        padding: 0 10px 10px 0;
+    }
+    .wagtail-inventory-select .select-has {
+        width: 175px;
+    }
+    .wagtail-inventory-select .field-content {
+        width: 100%;
+    }
 </style>
 {% endblock %}
 

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -37,7 +37,7 @@
       {% include "wagtailadmin/shared/field.html" with field=form.block show_label=False field_classes="select-block" %}
     </div>
   {% endfor %}
-  <input type="submit" value="Find matching pages" style="width: 240px; padding: 10px; margin: 10px 0" />
+  <input type="submit" value="Find matching pages" class="button" style="margin: 10px 0 20px;" />
 </form>
 
 <div id="search-results">


### PR DESCRIPTION
As reported in #39, the select dropdowns in the admin search form should have chevron icons to indicate that they can be selected.

This commit adds those icons by leveraging the built-in field template in the Wagtail admin ([wagtailadmin/shared/field.html](https://github.com/wagtail/wagtail/blob/master/wagtail/admin/templates/wagtailadmin/shared/field.html)). This also allows us to simplify the form and HTML code a bit.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/104495784-2e05db80-55a6-11eb-8685-ddd785c036d0.png)

## Notes

This is an alternate approach than #40 that tries to leverage the built-in Wagtail template instead of using custom HTML.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: