### PR TITLE
Update helpers.py to detect and correct for row duplication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.6
 
       - name: Install dependencies
         run: |
@@ -72,3 +72,4 @@ jobs:
         env: 
           TOXENV: ${{ matrix.toxenv }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -54,12 +54,31 @@ def get_page_inventory(page=None):
 
 
 def create_page_inventory(page):
+    """
+    Customized as per https://github.com/mozilla/foundation.mozilla.org/issues/6162
+    """
     page_blocks = get_page_blocks(page)
 
-    return [
-        PageBlock.objects.get_or_create(page=page, block=block)[0]
-        for block in page_blocks
-    ]
+    # return [
+    #     PageBlock.objects.get_or_create(page=page, block=block)[0]
+    #     for block in page_blocks
+    # ]
+
+    list = []
+
+    for block in page_blocks:
+        bindings = PageBlock.objects.filter(page=page, block=block)
+
+        if bindings.count() > 0:
+            list.append(bindings.first())
+            for index, entry in enumerate(bindings):
+                if index > 0:
+                    entry.delete()
+        else:
+            result = PageBlock.objects.create(page=page, block=block)
+            list.append(result)
+
+    return list
 
 
 def delete_page_inventory(page=None):

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -55,14 +55,13 @@ def get_page_inventory(page=None):
 
 def create_page_inventory(page):
     """
-    Customized as per https://github.com/mozilla/foundation.mozilla.org/issues/6162
+    Rather than working with get_or_create, this code
+    works by filtering for the target page, and
+    deduplicating if it finds more than one record
+    for any page/block combination (e.g. due to
+    database corruption, concurrents writes, etc).
     """
     page_blocks = get_page_blocks(page)
-
-    # return [
-    #     PageBlock.objects.get_or_create(page=page, block=block)[0]
-    #     for block in page_blocks
-    # ]
 
     list = []
 


### PR DESCRIPTION
As per https://github.com/cfpb/wagtail-inventory/issues/43, it is possible to get the DB in a state where there are multiple {page,block} records, causing a crash in `helper.py`'s `create_page_inventory` function.

This PR is current a starting point, to find a good code solution. I personally find this one the best because it both detects _and fixes_ the problem all on its own, but I suspect we'll iterate on this one a bit?

## Additions

I added code that checks for pre-existing rows and _counts_ how many there are, with db pruning if more than one row is found.

## Removals

for now, simply commented off: the original `get_or_create` got "removed" because by design it can't deal with more than one result.

## Changes

-

## Testing

1. I honestly don't know how to test this, short of using `Q()` instructions to intentionally create a corrupt database.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
