### PR TITLE
Add UniqueConstraint on (page, block)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22,31}-wag{27,latest}
+    py{36,38}-dj22-wag27,
+    py{36,38}-dj{22,31}-waglatest
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/wagtailinventory/migrations/0002_pageblock_unique_constraint.py
+++ b/wagtailinventory/migrations/0002_pageblock_unique_constraint.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+from django.db.models import Min, Count
+
+
+def remove_duplicates(apps, schema_editor):
+    PageBlock = apps.get_model('wagtailinventory', 'PageBlock')
+
+    duplicate_pks_to_keep = (
+        PageBlock.objects
+            .values('page', 'block')
+            .annotate(Min('pk'), count=Count('pk'))
+            .filter(count__gt=1)
+            .values_list('pk__min', flat=True)
+    )
+
+    duplicates_to_keep = PageBlock.objects.in_bulk(duplicate_pks_to_keep)
+
+    for duplicate_to_keep in duplicates_to_keep.values():
+        duplicates_to_delete = PageBlock.objects.filter(
+            page=duplicate_to_keep.page,
+            block=duplicate_to_keep.block
+        ).exclude(pk=duplicate_to_keep.pk)
+
+        duplicates_to_delete.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailinventory', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_duplicates, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name='pageblock',
+            constraint=models.UniqueConstraint(fields=('page', 'block'), name='unique_page_block'),
+        ),
+    ]

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -9,5 +9,12 @@ class PageBlock(models.Model):
     )
     block = models.CharField(max_length=255, db_index=True)
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["page", "block"], name="unique_page_block"
+            ),
+        ]
+
     def __str__(self):
         return "<{}, {}>".format(self.page, self.block)


### PR DESCRIPTION
More explicitly prevent the possibility of duplicate PageBlocks in the database.

An alternate approach to #44 and hopeful fix to #43, assuming it is caused by the lack of database constraint as suggested by the Django documentation [here](https://docs.djangoproject.com/en/dev/ref/models/querysets/#get-or-create):

> **Warning**
>
> [`get_or_create`] is atomic assuming that the database enforces uniqueness of the keyword arguments (see `unique` or `unique_together`). If the fields used in the keyword arguments do not have a uniqueness constraint, concurrent calls to this method may result in multiple rows with the same parameters being inserted.