### PR TITLE
to add custom pemissions to the block inventory

### DIFF
--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -15,6 +15,7 @@ class PageBlock(models.Model):
                 fields=["page", "block"], name="unique_page_block"
             ),
         ]
+        permissions = [('can_search_inventory', 'Can Search in Wagtail Inventory')]
 
     def __str__(self):
         return "<{}, {}>".format(self.page, self.block)

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -15,7 +15,7 @@ class PageBlock(models.Model):
                 fields=["page", "block"], name="unique_page_block"
             ),
         ]
-        permissions = [('can_search_inventory', 'Can Search in Wagtail Inventory')]
+        permissions = [('index_wagtailinventory', 'Can Search in Wagtail Inventory')]
 
     def __str__(self):
         return "<{}, {}>".format(self.page, self.block)

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.contrib.auth.models import Permission
 
 from wagtailinventory import urls
 from wagtailinventory.helpers import (
@@ -77,4 +78,5 @@ def register_inventory_menu_item():
         reverse("wagtailinventory:search"),
         classnames="icon icon-placeholder",
         order=11000,
+        permission='wagtailinventory.index_wagtailinventory'
     )

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -14,10 +14,10 @@ except ImportError:  # pragma: no cover; fallback for Django <1.10
     from django.core.urlresolvers import reverse
 
 try:
-    from wagtail.admin.menu import MenuItem
+    from wagtail.admin.menu import MenuItem, AdminOnlyMenuItem
     from wagtail.core import hooks  # pragma: no cover
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailadmin.menu import MenuItem
+    from wagtail.wagtailadmin.menu import MenuItem, AdminOnlyMenuItem
     from wagtail.wagtailcore import hooks
 
 
@@ -45,7 +45,7 @@ def register_inventory_urls():
 
 @hooks.register("register_settings_menu_item")
 def register_inventory_menu_item():
-    return MenuItem(
+    return AdminOnlyMenuItem(
         "Block Inventory",
         reverse("wagtailinventory:search"),
         classnames="icon icon-placeholder",

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -34,7 +34,8 @@ class PermissionCheckingMenuItem(MenuItem):
         super(PermissionCheckingMenuItem, self).__init__(*args, **kwargs)
 
     def is_shown(self, request):
-        return request.user.has_perm(self.permission)
+        if request.user.is_superuser or request.user.has_perm(self.permission):
+            return True
 
 
 @hooks.register("after_create_page")
@@ -57,6 +58,16 @@ def register_inventory_urls():
     return [
         url(r"^inventory/", include(urls, namespace="wagtailinventory")),
     ]
+
+
+
+
+@hooks.register('register_permissions')
+def register_permissions():
+    return Permission.objects.filter(
+        content_type__app_label='wagtailinventory',
+        codename__in=['index_wagtailinventory',]
+    )
 
 
 @hooks.register("register_settings_menu_item")


### PR DESCRIPTION
to prevent non-superusers from seeing the block inventory menu item, I used the (AdminOnlyMenuItem) instead of (MenuItem) to solve #47 issue
