### PR TITLE
Wagtail 2.15 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,11 @@ jobs:
             - py39-dj22-waglatest
             - py39-dj32-waglatest
         include:
-          - toxenv: py36-dj22-wag27
+          - toxenv: py36-dj32-wag215
             python-version: 3.6
-          - toxenv: py36-dj22-waglatest
+          - toxenv: py36-dj32-waglatest
             python-version: 3.6
-          - toxenv: py39-dj22-waglatest
+          - toxenv: py39-dj32-wag215
             python-version: 3.9
           - toxenv: py39-dj32-waglatest
             python-version: 3.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22-wag27
-            - py36-dj22-waglatest
-            - py39-dj22-waglatest
+            - py36-dj32-wag215
+            - py36-dj32-waglatest
+            - py39-dj32-wag215
             - py39-dj32-waglatest
         include:
           - toxenv: py36-dj32-wag215

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Install the package using pip:
 .. code-block:: bash
 
   $ pip install wagtail-inventory
- 
+
 Add ``wagtailinventory`` as an installed app in your Django settings:
 
 .. code-block:: python
@@ -52,8 +52,8 @@ Compatibility
 This code has been tested for compatibility with:
 
 * Python 3.6+
-* Django 2.2 (LTS), 3.1 (current)
-* Wagtail 2.7 (LTS), 2.10 (current)
+* Django 3.2 (LTS)
+* Wagtail 2.15 (LTS), 2.16 (current)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description="Lookup Wagtail pages by block content",
     long_description=open("README.rst", "r", encoding="utf-8").read(),
     license="CCO",
-    version="1.3",
+    version="1.4",
     version_format="{tag}.dev{commitcount}+{gitsha}",
     include_package_data=True,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm==4.15.0",
-    "wagtail>=2.7,<3",
+    "wagtail>=2.15,<3",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj22-wag{27,latest}
-    py{39}-dj{22,32}-wag{latest}
+    py{36}-dj32-wag{215,latest}
+    py{39}-dj32-wag{215,latest}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -20,10 +20,9 @@ basepython=
 
 deps=
     mock>=1.0.0
-    dj22:  Django>=2.2,<2.3
     dj32:  Django>=3.2,<3.3
-    wag27: wagtail>=2.7,<2.8
-    waglatest: wagtail>=2.10,<3
+    wag215: wagtail>=2.15,<2.16
+    waglatest: wagtail>=2.15,<3
 
 [testenv:lint]
 basepython=python3.9

--- a/wagtailinventory/templates/wagtailinventory/_list_explore_inventory.html
+++ b/wagtailinventory/templates/wagtailinventory/_list_explore_inventory.html
@@ -1,0 +1,4 @@
+{% extends 'wagtailadmin/pages/listing/_list_explore.html' %}
+
+{% block page_navigation %}
+{% endblock %}

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -62,7 +62,7 @@
         {% endblocktrans %}
       </h2>
 
-      {% include "wagtailinventory/_list_explore_inventory.html" with show_parent=1 show_bulk_actions=1 %}
+      {% include "wagtailinventory/_list_explore_inventory.html" with show_parent=1 show_bulk_actions=1 allow_navigation=0 %}
       {% include "wagtailadmin/shared/pagination_nav.html" with items=pages %}
       {% trans "Select all pages in listing" as select_all_text %}
       {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=pages %}

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -62,7 +62,7 @@
         {% endblocktrans %}
       </h2>
 
-      {% include "wagtailinventory/_list_explore_inventory.html" with show_parent=1 show_bulk_actions=1 allow_navigation=0 %}
+      {% include "wagtailinventory/_list_explore_inventory.html" with show_parent=1 show_bulk_actions=1 %}
       {% include "wagtailadmin/shared/pagination_nav.html" with items=pages %}
       {% trans "Select all pages in listing" as select_all_text %}
       {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=pages %}

--- a/wagtailinventory/templates/wagtailinventory/search.html
+++ b/wagtailinventory/templates/wagtailinventory/search.html
@@ -28,6 +28,14 @@
 </style>
 {% endblock %}
 
+{% block extra_js %}
+   {{ block.super }}
+   <script>
+       window.wagtailConfig.BULK_ACTION_ITEM_TYPE = 'PAGE';
+   </script>
+   <script defer src="{% versioned_static 'wagtailadmin/js/bulk-actions.js' %}"></script>
+{% endblock %}
+
 {% block content %}
 {% trans "Block Inventory" as header_str %}
 {% include "wagtailadmin/shared/header.html" with title=header_str icon="placeholder" %}
@@ -54,8 +62,10 @@
         {% endblocktrans %}
       </h2>
 
-      {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
+      {% include "wagtailinventory/_list_explore_inventory.html" with show_parent=1 show_bulk_actions=1 %}
       {% include "wagtailadmin/shared/pagination_nav.html" with items=pages %}
+      {% trans "Select all pages in listing" as select_all_text %}
+      {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label='wagtailcore' model_name='page' objects=pages %}
     </div>
   {% else %}
     <div class="nice-padding">


### PR DESCRIPTION
* Adds support for Wagtail 2.15
* Removes support for less than 2.15
* Adds Bulk Actions to search table results
* Bumps version to 1.4
* Drops Django 2.2 support

We tried to have a great way to support previous Wagtail versions, but with the `bulk_actions/footer.html` being moved in 2.15, it's a mess to support.

Closes #50 