### PR TITLE
Use any compatible tqdm version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "tqdm==4.15.0",
+    "tqdm>=4.15.0,<5",
     "wagtail>=2.15,<3",
 ]
 


### PR DESCRIPTION
`tqdm~=4.15` could also work, but decided to match the version range specified for wagtail

Fixes #52
