### PR TITLE
Fix flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,10 +9,8 @@ ignore =
     # PEP8 weakly recommends Knuth-style line breaks before binary
     # operators
     W503, W504
-exclude =
+extend-exclude =
     # These are directories that it's a waste of time to traverse
-    .git,
-    .tox,
     .venv,
     docs,
     venv,
@@ -20,4 +18,4 @@ exclude =
     # Generated migration files will throw errors. We need to find a way
     # to exclude django-generated migrations while including
     # manually-written migrations.
-    */migrations/*.py,
+    **/migrations/*.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-exclude = wagtailinventory/migrations/*

--- a/tox.ini
+++ b/tox.ini
@@ -36,15 +36,6 @@ commands=
     flake8 wagtailinventory setup.py
     isort --check-only --diff wagtailinventory
 
-[flake8]
-ignore=E731,W503,W504
-exclude=
-    .git,
-    .tox,
-    __pycache__,
-    */migrations/*.py,
-    */tests/testapp/migrations/*.py,
-
 [isort]
 combine_as_imports=1
 lines_after_imports=2


### PR DESCRIPTION
"tox -e lint" was failing on this repository. There were multiple conflicting configurations for flake8: in .flake8, tox, and setup.cfg.

This commit simplifies so that the configuration only lives in .flake8, and works again even on the latest version of flake8.