### PR TITLE
Add support for Wagtail 3 and Wagtail 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -31,25 +31,36 @@ jobs:
 
     strategy:
       matrix:
-        toxenv:
-            - py36-dj32-wag215
-            - py39-dj32-wag215
-            - py39-dj40-wag216
+        python: ['3.8', '3.10']
+        django: ['3.2']
+        wagtail: ['2.15','3.0','4.0']
         include:
-          - toxenv: py36-dj32-wag215
-            python-version: 3.6
-          - toxenv: py39-dj32-wag215
-            python-version: 3.9
-          - toxenv: py39-dj40-wag216
-            python-version: 3.9
+          - python: '3.8'
+            django: '4.0'
+            wagtail: '3.0'
+          - python: '3.10'
+            django: '4.0'
+            wagtail: '3.0'
+          - python: '3.8'
+            django: '4.0'
+            wagtail: '4.0'
+          - python: '3.10'
+            django: '4.0'
+            wagtail: '4.0'
+          - python: '3.8'
+            django: '4.1'
+            wagtail: '4.0'
+          - python: '3.10'
+            django: '4.1'
+            wagtail: '4.0'
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: |
@@ -61,6 +72,6 @@ jobs:
             tox
             coveralls
         env:
-          TOXENV: ${{ matrix.toxenv }}
+          TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github

--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ Compatibility
 This code has been tested for compatibility with:
 
 * Python 3.6+
-* Django 3.2 (LTS), Django 4.0 (Current)
-* Wagtail 2.15 (LTS), Wagtail 2.16 (Current)
+* Django 3.2 (LTS), 4.0, 4.1
+* Wagtail 2.15 (LTS), 3.0, 4.0
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,19 @@ If you find that it is not, please `file an issue <https://github.com/cfpb/wagta
 Testing
 -------
 
-Run unit tests with ``tox`` to test against select supported package combinations.
+Running project unit tests requires `tox <https://tox.wiki/en/latest/>`_:
+
+.. code-block:: bash
+
+  $ tox
+
+To run the test app interactively, run:
+
+.. code-block:: bash
+
+  $ tox -e interactive
+
+Now you can visit http://localhost:8000/admin/ in a browser and log in with ``admin`` / ``changeme``.
 
 Open source licensing info
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm>=4.15.0,<5",
-    "wagtail>=2.15,<3",
+    "wagtail>=2.15,<4.1",
 ]
 
 
@@ -23,16 +23,17 @@ setup(
     version="1.5",
     include_package_data=True,
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
+        "Framework :: Wagtail :: 3",
+        "Framework :: Wagtail :: 4",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",
         "Programming Language :: Python",

--- a/testmanage.py
+++ b/testmanage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import shutil
+import sys
+import warnings
+
+from django.core.management import execute_from_command_line
+
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "wagtailinventory.tests.settings"
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--deprecation",
+        choices=["all", "pending", "imminent", "none"],
+        default="imminent",
+    )
+    return parser
+
+
+def parse_args(args=None):
+    return make_parser().parse_known_args(args)
+
+
+def runtests():
+    args, rest = parse_args()
+
+    only_wagtail = r"^wagtail(\.|$)"
+    if args.deprecation == "all":
+        # Show all deprecation warnings from all packages
+        warnings.simplefilter("default", DeprecationWarning)
+        warnings.simplefilter("default", PendingDeprecationWarning)
+    elif args.deprecation == "pending":
+        # Show all deprecation warnings from wagtail
+        warnings.filterwarnings(
+            "default", category=DeprecationWarning, module=only_wagtail
+        )
+        warnings.filterwarnings(
+            "default", category=PendingDeprecationWarning, module=only_wagtail
+        )
+    elif args.deprecation == "imminent":
+        # Show only imminent deprecation warnings from wagtail
+        warnings.filterwarnings(
+            "default", category=DeprecationWarning, module=only_wagtail
+        )
+    elif args.deprecation == "none":
+        # Deprecation warnings are ignored by default
+        pass
+
+    argv = [sys.argv[0]] + rest
+
+    try:
+        execute_from_command_line(argv)
+    finally:
+        from wagtail.tests.settings import MEDIA_ROOT, STATIC_ROOT
+
+        shutil.rmtree(STATIC_ROOT, ignore_errors=True)
+        shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    runtests()

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,8 @@ envlist=
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase
-    coverage run {envbindir}/django-admin test {posargs}
+    coverage run {toxinidir}/testmanage.py test {posargs}
     coverage report --show-missing --fail-under=100
-setenv=
-    DJANGO_SETTINGS_MODULE=wagtailinventory.tests.settings
 
 basepython=
     python3.8: python3.8
@@ -35,9 +33,25 @@ deps=
     flake8
     isort
 commands=
-    black --check wagtailinventory setup.py
-    flake8 wagtailinventory setup.py
-    isort --check-only --diff wagtailinventory
+    black --check wagtailinventory setup.py testmanage.py
+    flake8 wagtailinventory setup.py testmanage.py
+    isort --check-only --diff wagtailinventory testmanage.py
+
+[testenv:interactive]
+basepython=python3.8
+
+commands_pre=
+    python {toxinidir}/testmanage.py makemigrations
+    python {toxinidir}/testmanage.py migrate
+    python {toxinidir}/testmanage.py shell -c "from django.contrib.auth.models import User;(not User.objects.filter(username='admin').exists()) and User.objects.create_superuser('admin', 'super@example.com', 'changeme')"
+    python {toxinidir}/testmanage.py loaddata wagtailinventory/fixtures/test_blocks.json
+    python {toxinidir}/testmanage.py block_inventory
+
+commands=
+    {posargs:python testmanage.py runserver 0.0.0.0:8000}
+
+setenv=
+    INTERACTIVE=1
 
 [isort]
 combine_as_imports=1

--- a/tox.ini
+++ b/tox.ini
@@ -2,31 +2,34 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,39}-dj32-wag215,
-    py39-dj40-wag216
+    python{3.8,3.10}-django{3.2}-wagtail{2.15,3.0,4.0}
+    python{3.8,3.10}-django{4.0}-wagtail{3.0,4.0}
+    python{3.8,3.10}-django{4.1}-wagtail{4.0}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase
     coverage run {envbindir}/django-admin test {posargs}
-    coverage report -m
+    coverage report --show-missing --fail-under=100
 setenv=
     DJANGO_SETTINGS_MODULE=wagtailinventory.tests.settings
 
 basepython=
-    py36: python3.6
-    py39: python3.9
+    python3.8: python3.8
+    python3.10: python3.10
 
 deps=
     mock>=1.0.0
-    dj32:  Django>=3.2,<3.3
-    dj40:  Django>=4.0,<4.1
-    wag215: wagtail>=2.15,<2.16
-    wag216: wagtail>=2.16,<2.17
+    django3.2: Django>=3.2,<3.3
+    django4.0: Django>=4.0,<4.1
+    django4.1: Django>=4.1,<4.2
+    wagtail2.15: wagtail>=2.15,<2.16
+    wagtail3.0: wagtail>=3.0,<3.1
+    wagtail4.0: wagtail>=4.0,<4.1
 
 [testenv:lint]
-basepython=python3.9
+basepython=python3.8
 deps=
     black
     flake8

--- a/wagtailinventory/fixtures/test_blocks.json
+++ b/wagtailinventory/fixtures/test_blocks.json
@@ -1,22 +1,5 @@
 [
 {
-    "model": "auth.user",
-    "fields": {
-        "password": "pbkdf2_sha256$100000$RKUa1ZdWARZL$rG55GlxBES3r1bDuInG/z9IthbzqS43lehVwXGx4Ke4=",
-        "last_login": "2018-06-11T11:43:09.976",
-        "is_superuser": true,
-        "username": "admin",
-        "first_name": "",
-        "last_name": "",
-        "email": "admin@admin.admin",
-        "is_staff": true,
-        "is_active": true,
-        "date_joined": "2018-06-11T11:42:56.375",
-        "groups": [],
-        "user_permissions": []
-    }
-},
-{
     "model": "wagtailcore.page",
     "pk": 3,
     "fields": {
@@ -33,9 +16,6 @@
         "live": false,
         "has_unpublished_changes": true,
         "url_path": "/home/single-streamfield-page-no-content/",
-        "owner": [
-            "admin"
-        ],
         "seo_title": "",
         "show_in_menus": false,
         "search_description": "",
@@ -66,9 +46,6 @@
         "live": false,
         "has_unpublished_changes": true,
         "url_path": "/home/single-streamfield-page-content/",
-        "owner": [
-            "admin"
-        ],
         "seo_title": "",
         "show_in_menus": false,
         "search_description": "",
@@ -99,9 +76,6 @@
         "live": false,
         "has_unpublished_changes": true,
         "url_path": "/home/multiple-streamfields-page/",
-        "owner": [
-            "admin"
-        ],
         "seo_title": "",
         "show_in_menus": false,
         "search_description": "",
@@ -132,9 +106,6 @@
         "live": false,
         "has_unpublished_changes": true,
         "url_path": "/home/nested-streamblock-page/",
-        "owner": [
-            "admin"
-        ],
         "seo_title": "",
         "show_in_menus": false,
         "search_description": "",
@@ -165,9 +136,6 @@
         "live": false,
         "has_unpublished_changes": true,
         "url_path": "/home/no-streamfields-page/",
-        "owner": [
-            "admin"
-        ],
         "seo_title": "",
         "show_in_menus": false,
         "search_description": "",

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -19,7 +19,7 @@ class PageBlockQueryForm(forms.Form):
 
     has = forms.ChoiceField(
         choices=((c, c) for c in (INCLUDES_BLOCK, EXCLUDES_BLOCK)),
-        label=None,
+        label=None
     )
 
     def __init__(self, *args, **kwargs):

--- a/wagtailinventory/forms.py
+++ b/wagtailinventory/forms.py
@@ -18,8 +18,7 @@ class PageBlockQueryForm(forms.Form):
     )
 
     has = forms.ChoiceField(
-        choices=((c, c) for c in (INCLUDES_BLOCK, EXCLUDES_BLOCK)),
-        label=None
+        choices=((c, c) for c in (INCLUDES_BLOCK, EXCLUDES_BLOCK)), label=None
     )
 
     def __init__(self, *args, **kwargs):

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -27,8 +27,6 @@ def get_field_blocks(value):
     block = getattr(value, "block", None)
     blocks = [block] if block else []
 
-    if isinstance(value, list):
-        child_blocks = value
     if isinstance(block, StructBlock):
         if hasattr(value, "bound_blocks"):
             child_blocks = value.bound_blocks.values()

--- a/wagtailinventory/migrations/0002_pageblock_unique_constraint.py
+++ b/wagtailinventory/migrations/0002_pageblock_unique_constraint.py
@@ -2,7 +2,7 @@ from django.db import migrations, models
 from django.db.models import Min, Count
 
 
-def remove_duplicates(apps, schema_editor):
+def remove_duplicates(apps, schema_editor):  # pragma: no cover
     PageBlock = apps.get_model('wagtailinventory', 'PageBlock')
 
     duplicate_pks_to_keep = (

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -86,3 +86,5 @@ TEMPLATES = [
 WAGTAIL_SITE_NAME = "Test Site"
 
 ROOT_URLCONF = "wagtailinventory.tests.urls"
+
+WAGTAILADMIN_BASE_URL = "http://localhost:8000"

--- a/wagtailinventory/tests/test_forms.py
+++ b/wagtailinventory/tests/test_forms.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from wagtail.core.models import Page, Site
 
-from wagtailinventory.forms import PageBlockQueryForm
+from wagtailinventory.forms import PageBlockQueryForm, PageBlockQueryFormSet
 from wagtailinventory.models import PageBlock
 
 
@@ -34,3 +34,65 @@ class TestPageBlockQueryForm(TestCase):
         self.assertEqual(form_choices[1][0], "blocks.apple")
         self.assertEqual(form_choices[2][0], "blocks.banana")
         self.assertEqual(form_choices[3][0], "blocks.mango")
+
+
+class TestPageBlockQueryFormSet(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.root_page = Page.objects.get(pk=1)
+        cls.site_root = Site.objects.get(is_default_site=True).root_page
+
+        cls.apple_page = Page(title="Apple", slug="apple")
+        cls.site_root.add_child(instance=cls.apple_page)
+        PageBlock.objects.create(page=cls.apple_page, block="blocks.apple")
+
+        cls.banana_page = Page(title="Banana", slug="banana")
+        cls.site_root.add_child(instance=cls.banana_page)
+        PageBlock.objects.create(page=cls.banana_page, block="blocks.banana")
+
+    def test_empty_formset_returns_all_pages(self):
+        formset = PageBlockQueryFormSet(
+            data={
+                "form-TOTAL_FORMS": "1",
+                "form-INITIAL_FORMS": "0",
+            }
+        )
+        self.assertQuerysetEqual(formset.get_query(), Page.objects.all())
+
+    def test_invalid_formset_returns_all_pages(self):
+        formset = PageBlockQueryFormSet(
+            data={
+                "form-TOTAL_FORMS": "1",
+                "form-INITIAL_FORMS": "0",
+                "form-0-block": "invalid",
+                "form-0-has": None,
+            }
+        )
+        self.assertQuerysetEqual(formset.get_query(), Page.objects.all())
+
+    def test_formset_filtering_includes(self):
+        formset = PageBlockQueryFormSet(
+            data={
+                "form-TOTAL_FORMS": "1",
+                "form-INITIAL_FORMS": "0",
+                "form-0-block": "blocks.apple",
+                "form-0-has": PageBlockQueryForm.INCLUDES_BLOCK,
+            }
+        )
+        self.assertQuerysetEqual(formset.get_query(), [self.apple_page])
+
+    def test_formset_filtering_excludes(self):
+        formset = PageBlockQueryFormSet(
+            data={
+                "form-TOTAL_FORMS": "1",
+                "form-INITIAL_FORMS": "0",
+                "form-0-block": "blocks.apple",
+                "form-0-has": PageBlockQueryForm.EXCLUDES_BLOCK,
+            }
+        )
+        self.assertQuerysetEqual(
+            formset.get_query(),
+            [self.root_page, self.site_root, self.banana_page],
+        )

--- a/wagtailinventory/tests/test_helpers.py
+++ b/wagtailinventory/tests/test_helpers.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.management import call_command
 from django.test import TestCase
 

--- a/wagtailinventory/tests/test_helpers.py
+++ b/wagtailinventory/tests/test_helpers.py
@@ -3,17 +3,20 @@ import json
 from django.core.management import call_command
 from django.test import TestCase
 
+import wagtail
 from wagtail.core.models import Page
 
 from wagtailinventory.helpers import (
-    create_page_inventory,
     get_page_blocks,
     get_page_inventory,
     update_page_inventory,
 )
 
 
-CORE_BLOCKS = "wagtail.core.blocks"
+if wagtail.VERSION < (3, 0):  # pragma: nocover
+    CORE_BLOCKS = "wagtail.core.blocks"
+else:
+    CORE_BLOCKS = "wagtail.blocks"
 
 
 class TestGetPageBlocks(TestCase):

--- a/wagtailinventory/tests/test_helpers.py
+++ b/wagtailinventory/tests/test_helpers.py
@@ -1,8 +1,16 @@
+import json
+
+from django.core.management import call_command
 from django.test import TestCase
 
 from wagtail.core.models import Page
 
-from wagtailinventory.helpers import get_page_blocks
+from wagtailinventory.helpers import (
+    create_page_inventory,
+    get_page_blocks,
+    get_page_inventory,
+    update_page_inventory,
+)
 
 
 CORE_BLOCKS = "wagtail.core.blocks"
@@ -52,3 +60,31 @@ class TestGetPageBlocks(TestCase):
                 "wagtailinventory.tests.testapp.blocks.Atom",
             ],
         )
+
+
+class TestPageInventoryHelpers(TestCase):
+    fixtures = ["test_blocks.json"]
+
+    def setUp(self):
+        call_command("block_inventory", verbosity=0)
+
+    def test_get_all_pageblocks(self):
+        self.assertEqual(get_page_inventory().count(), 10)
+
+    def test_get_pageblocks_filtered_by_page(self):
+        page = Page.objects.get(slug="single-streamfield-page-content")
+        self.assertEqual(get_page_inventory(page).count(), 2)
+
+    def test_update_page(self):
+        # First the page has 2 blocks.
+        page = Page.objects.get(slug="single-streamfield-page-content")
+        self.assertEqual(get_page_inventory(page).count(), 2)
+
+        # Delete the page's blocks.
+        page = page.specific
+        page.content = []
+        page.save_revision().publish()
+
+        # Updating the page should remove the block inventory.
+        update_page_inventory(page)
+        self.assertEqual(get_page_inventory(page).count(), 0)

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -48,7 +48,7 @@ class SearchViewTests(WagtailTestUtils, TestCase):
                 "form-TOTAL_FORMS": 1,
                 "form-INITIAL_FORMS": 0,
                 "form-0-has": "includes",
-                "form-0-block": "wagtailinventory.tests.testapp.blocks.Organism",  # noqa
+                "form-0-block": "wagtailinventory.tests.testapp.blocks.Organism",
             }
         )
         self.assertEqual(response.status_code, 200)

--- a/wagtailinventory/tests/test_wagtail_hooks.py
+++ b/wagtailinventory/tests/test_wagtail_hooks.py
@@ -1,5 +1,3 @@
-import json
-
 from django.test import TestCase
 from django.urls import reverse
 

--- a/wagtailinventory/tests/test_wagtail_hooks.py
+++ b/wagtailinventory/tests/test_wagtail_hooks.py
@@ -1,2 +1,106 @@
-# flake8: noqa
-from wagtailinventory import wagtail_hooks
+import json
+
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.core.models import Page, Site
+from wagtail.tests.utils import WagtailTestUtils
+
+from wagtailinventory.models import PageBlock
+
+
+class TestWagtailHooks(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.root_page = Site.objects.get(is_default_site=True).root_page
+
+        self.login()
+
+    def test_inventory_hooks(self):
+        self.assertEqual(PageBlock.objects.all().count(), 0)
+
+        # Creating a page should create its inventory with 2 blocks.
+        post_data = {
+            "title": "test",
+            "slug": "test",
+            "content-count": 2,
+            "content-0-deleted": "",
+            "content-0-order": 0,
+            "content-0-type": "atom",
+            "content-0-value-title": "atom",
+            "content-1-deleted": "",
+            "content-1-order": 1,
+            "content-1-type": "molecule",
+            "content-1-value-title": "molecule",
+            "content-1-value-atoms-count": 0,
+        }
+
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("testapp", "singlestreamfieldpage", self.root_page.id),
+            ),
+            post_data,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        page = Page.objects.get(slug="test")
+
+        self.assertEqual(
+            list(PageBlock.objects.values_list("page", flat=True)),
+            [page.pk] * 4,
+        )
+        self.assertEqual(
+            list(
+                PageBlock.objects.order_by("block").values_list(
+                    "block", flat=True
+                )
+            ),
+            [
+                "wagtail.core.blocks.field_block.CharBlock",
+                "wagtail.core.blocks.list_block.ListBlock",
+                "wagtailinventory.tests.testapp.blocks.Atom",
+                "wagtailinventory.tests.testapp.blocks.Molecule",
+            ],
+        )
+
+        # Updating the page should update its inventory.
+        post_data = {
+            "title": "test",
+            "slug": "test",
+            "content-count": 1,
+            "content-0-deleted": "",
+            "content-0-order": 0,
+            "content-0-type": "atom",
+            "content-0-value-title": "modified",
+            "action-publish": "Publish",
+        }
+
+        response = self.client.post(
+            reverse("wagtailadmin_pages:edit", args=[page.pk]),
+            post_data,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(
+            list(PageBlock.objects.values_list("page", flat=True)),
+            [page.pk] * 2,
+        )
+        self.assertEqual(
+            list(
+                PageBlock.objects.order_by("block").values_list(
+                    "block", flat=True
+                )
+            ),
+            [
+                "wagtail.core.blocks.field_block.CharBlock",
+                "wagtailinventory.tests.testapp.blocks.Atom",
+            ],
+        )
+
+        # Deleting the page should delete its inventory.
+        response = self.client.post(
+            reverse("wagtailadmin_pages:delete", args=[page.pk]),
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(PageBlock.objects.count(), 0)

--- a/wagtailinventory/tests/test_wagtail_hooks.py
+++ b/wagtailinventory/tests/test_wagtail_hooks.py
@@ -3,10 +3,17 @@ import json
 from django.test import TestCase
 from django.urls import reverse
 
+import wagtail
 from wagtail.core.models import Page, Site
 from wagtail.tests.utils import WagtailTestUtils
 
 from wagtailinventory.models import PageBlock
+
+
+if wagtail.VERSION < (3, 0):  # pragma: nocover
+    CORE_BLOCKS = "wagtail.core.blocks"
+else:
+    CORE_BLOCKS = "wagtail.blocks"
 
 
 class TestWagtailHooks(TestCase, WagtailTestUtils):
@@ -56,8 +63,8 @@ class TestWagtailHooks(TestCase, WagtailTestUtils):
                 )
             ),
             [
-                "wagtail.core.blocks.field_block.CharBlock",
-                "wagtail.core.blocks.list_block.ListBlock",
+                CORE_BLOCKS + ".field_block.CharBlock",
+                CORE_BLOCKS + ".list_block.ListBlock",
                 "wagtailinventory.tests.testapp.blocks.Atom",
                 "wagtailinventory.tests.testapp.blocks.Molecule",
             ],
@@ -92,7 +99,7 @@ class TestWagtailHooks(TestCase, WagtailTestUtils):
                 )
             ),
             [
-                "wagtail.core.blocks.field_block.CharBlock",
+                CORE_BLOCKS + ".field_block.CharBlock",
                 "wagtailinventory.tests.testapp.blocks.Atom",
             ],
         )

--- a/wagtailinventory/tests/testapp/models.py
+++ b/wagtailinventory/tests/testapp/models.py
@@ -37,14 +37,14 @@ class MultipleStreamFieldsPage(Page):
             ("atom", blocks.Atom()),
             ("molecule", blocks.Molecule()),
             ("organism", blocks.Organism()),
-        ]
+        ],
     )
     second = StreamField(
         [
             ("atom", blocks.Atom()),
             ("molecule", blocks.Molecule()),
             ("organism", blocks.Organism()),
-        ]
+        ],
     )
 
     content_panels = Page.content_panels + [
@@ -65,7 +65,7 @@ class NestedStreamBlockPage(Page):
                     ]
                 ),
             ),
-        ]
+        ],
     )
 
     content_panels = Page.content_panels + [

--- a/wagtailinventory/urls.py
+++ b/wagtailinventory/urls.py
@@ -3,7 +3,7 @@ from wagtailinventory.views import SearchView
 
 try:
     from django.urls import re_path
-except ImportError:
+except ImportError:  # pragma: no cover
     from django.conf.urls import url as re_path
 
 

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -1,8 +1,8 @@
+from django.core.paginator import Paginator
 from django.http import HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.generic import View
 
-import wagtail
 from wagtail.core.models import Page
 
 from wagtailinventory.forms import PageBlockQueryFormSet
@@ -24,16 +24,8 @@ class SearchView(View):
 
         queryset = queryset.order_by("title")
 
-        # https://docs.wagtail.io/en/latest/releases/2.5.html#changes-to-admin-pagination-helpers
-        if wagtail.VERSION < (2, 5):
-            from wagtail.utils.pagination import paginate
-
-            paginator, pages = paginate(request, queryset)
-        else:  # pragma: no cover
-            from django.core.paginator import Paginator
-
-            paginator = Paginator(queryset, per_page=20)
-            pages = paginator.get_page(request.GET.get("p"))
+        paginator = Paginator(queryset, per_page=20)
+        pages = paginator.get_page(request.GET.get("p"))
 
         for page in pages:
             page.can_choose = True


### PR DESCRIPTION
This PR adds support for Wagtail 3.x and 4.x to this project. It modifies the tox testing matrix to now test against Wagtail 2.15  (LTS), 3.0, and 4.0. It also adds a new `tox -e interactive` to make it easier to test changes to this package, and bumps test source code coverage to 100%.

## Testing

See new test matrix in GitHub Actions.

## Notes

Thank you @nickmoreton and @katdom13 for your proposals in #58 and #60; I chose to combine the version upgrades into a single PR along with the other changes described above. If you have a chance to test this branch any feedback would be appreciated.

## Todos

Wagtail 4.0 changed the way fields are rendered in https://github.com/wagtail/wagtail/commit/eac5e0bc2cda0d78d1ffb13da32b8cc8410f2b0b, [specifically](https://github.com/wagtail/wagtail/blob/eac5e0bc2cda0d78d1ffb13da32b8cc8410f2b0b/wagtail/admin/templates/wagtailadmin/shared/field.html) which broke the (admittedly hacky) [hardcoded CSS](https://github.com/cfpb/wagtail-inventory/blob/867881602541ed8fadd0d2055e85f2d1de38ecd3/wagtailinventory/templates/wagtailinventory/search.html#L9-L28) that breaks how the includes/excludes button was being rendered next to the dropdown:

|Wagtail 2.16|Wagtail 4.0|Wagtail 4.0|
|-|-|-|
|<img width="1427" alt="image" src="https://user-images.githubusercontent.com/654645/199089982-72f3981c-a9b0-45f7-b930-4c81049d9a71.png">|<img width="1427" alt="image" src="https://user-images.githubusercontent.com/654645/199089816-0e992dcf-fb6b-4eb7-bc00-ef3c19411e1b.png">|<img width="1425" alt="image" src="https://user-images.githubusercontent.com/654645/199089514-e869c6f4-56f1-423d-af41-25ff8d393b9f.png">|

Given the interest in adding this version support, and since the form is still useable, I'd prefer not to (further) delay this upgrade because of that issue. I'm hopeful that it shouldn't be that difficult to re-add the previous design, but that would require better understanding of how fields are rendered in 4.x+.