### PR TITLE
Add support for Wagtail 4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python: ['3.8', '3.10']
         django: ['3.2']
-        wagtail: ['2.15','3.0','4.0']
+        wagtail: ['2.15','3.0','4.0','4.1']
         include:
           - python: '3.8'
             django: '4.0'
@@ -44,15 +44,27 @@ jobs:
           - python: '3.8'
             django: '4.0'
             wagtail: '4.0'
+          - python: '3.8'
+            django: '4.0'
+            wagtail: '4.1'
           - python: '3.10'
             django: '4.0'
             wagtail: '4.0'
+          - python: '3.10'
+            django: '4.0'
+            wagtail: '4.1'
           - python: '3.8'
+            django: '4.1'
+            wagtail: '4.0'
+          - python: '3.8'
+            django: '4.1'
+            wagtail: '4.1'
+          - python: '3.10'
             django: '4.1'
             wagtail: '4.0'
           - python: '3.10'
             django: '4.1'
-            wagtail: '4.0'
+            wagtail: '4.1'
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.6+
+* Python 3.8+
 * Django 3.2 (LTS), 4.0, 4.1
-* Wagtail 2.15 (LTS), 3.0, 4.0
+* Wagtail 2.15 (LTS), 3.0, 4.0, 4.1 (LTS)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "tqdm>=4.15.0,<5",
-    "wagtail>=2.15,<4.1",
+    "wagtail>=2.15,<4.2",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8,3.10}-django{3.2}-wagtail{2.15,3.0,4.0}
-    python{3.8,3.10}-django{4.0}-wagtail{3.0,4.0}
-    python{3.8,3.10}-django{4.1}-wagtail{4.0}
+    python{3.8,3.10}-django{3.2}-wagtail{2.15,3.0,4.0,4.1}
+    python{3.8,3.10}-django{4.0}-wagtail{3.0,4.0,4.1}
+    python{3.8,3.10}-django{4.1}-wagtail{4.0,4.1}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -25,6 +25,7 @@ deps=
     wagtail2.15: wagtail>=2.15,<2.16
     wagtail3.0: wagtail>=3.0,<3.1
     wagtail4.0: wagtail>=4.0,<4.1
+    wagtail4.1: wagtail>=4.1,<4.2
 
 [testenv:lint]
 basepython=python3.8


### PR DESCRIPTION
This commit adds support for Wagtail 4.1 and adds it to the testing matrix for tox and GitHub Actions.