### PR TITLE
Fix interactive tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,8 @@ commands=
 
 [testenv:interactive]
 basepython=python3.8
+deps=
+    Django>=3.2,<3.3
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations


### PR DESCRIPTION
Our `tox -e interactive` here is broken — it's not running the `install_command` from `testenv` because there are no `deps` specified for the `interactive` env. This small change adds Django in `deps` and so the `install_command` runs and the interactive environment works.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)