### PR TITLE
Add ruff to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     - id: black
       args: ["wagtailinventory", "setup.py", "--line-length=79"]
       exclude: migrations
--   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.254
     hooks:
-    - id: flake8
-      additional_dependencies: [flake8-bugbear==22.1.11]
+      - id: ruff
+        exclude: migrations
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ and patterns in the existing code-base.
 
 This project uses [`black`](https://github.com/psf/black) to format code,
 [`isort`](https://github.com/timothycrosley/isort) to format imports,
-and [`flake8`](https://gitlab.com/pycqa/flake8).
+and [`ruff`](https://github.com/charliermarsh/ruff).
 
 You can format code and imports by calling:
 

--- a/wagtailinventory/migrations/0001_initial.py
+++ b/wagtailinventory/migrations/0001_initial.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from django.db import migrations, models
 import django.db.models.deletion
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/wagtailinventory/migrations/0002_pageblock_unique_constraint.py
+++ b/wagtailinventory/migrations/0002_pageblock_unique_constraint.py
@@ -1,5 +1,5 @@
 from django.db import migrations, models
-from django.db.models import Min, Count
+from django.db.models import Count, Min
 
 
 def remove_duplicates(apps, schema_editor):  # pragma: no cover


### PR DESCRIPTION
Commit 792848dd4c4f864c1214b311ea43ce1a80cffc09 migrated this project from flake8 to ruff, but neglected to update the pre-commit config.

This commit does so. To test:

```
pip install pre-commit
pre-commit install
pre-commit run --all-files
```