### PR TITLE
Exempt PageBlock from Wagtail's reference index

### DIFF
--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -16,5 +16,7 @@ class PageBlock(models.Model):
             ),
         ]
 
+    wagtail_reference_index_ignore = True
+
     def __str__(self):
         return "<{}, {}>".format(self.page, self.block)


### PR DESCRIPTION
Wagtail 4.1 [introduced a new reference index](https://docs.wagtail.org/en/stable/releases/4.1.html#object-usage-reporting) that keeps track of Django model instance usage. In versions 4.1 and 4.2, this tracks instances from any Django model -- in 5.0 [this was changed](https://docs.wagtail.org/en/stable/releases/5.0.html#referenceindex-no-longer-tracks-models-used-outside-of-wagtail) so that only Wagtail-related models are tracked.

There's no need to track this project's PageBlock model class and, for sites with a large number of pages and/or blocks, the large number of PageBlock instances can increase the size and overhead of the reference index.

This commit exempts the PageBlock model from the index by setting `wagtail_reference_index_ignore = True`, as per the documentation [here](https://docs.wagtail.org/en/v4.1.6/advanced_topics/reference_index.html).