### PR TITLE
Add page type filtering to the inventory report

### DIFF
--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -1,5 +1,8 @@
-from wagtail.admin.filters import WagtailFilterSet
+from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.views.reports import PageReportView
+from wagtail.admin.views.reports.aging_pages import (
+    get_content_types_for_filter,
+)
 from wagtail.models import Page
 
 import django_filters
@@ -35,10 +38,14 @@ class BlockInventoryFilterSet(WagtailFilterSet):
             url="wagtailinventory:block_autocomplete"
         ),
     )
+    content_type = ContentTypeFilter(
+        label="Page Type",
+        queryset=lambda request: get_content_types_for_filter(),
+    )
 
     class Meta:
         model = Page
-        fields = ["include_page_blocks", "exclude_page_blocks"]
+        fields = ["include_page_blocks", "exclude_page_blocks", "content_type"]
 
 
 class BlockInventoryReportView(PageReportView):


### PR DESCRIPTION
This change adds the ability to filter the Block inventory report by page type. It uses a similar implementation to Wagtail's built-in Aging Page report.

## Testing

To test, run `tox -e interactive` and visit http://localhost:8000/admin/block-inventory/, then try filtering the results by page type.

## Screenshots

![image](https://github.com/cfpb/wagtail-inventory/assets/654645/142ff358-97e1-4ec3-972e-736889fb3adc)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests