### PR TITLE
Add ability to limit block inventory permission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,9 @@ Run a management command to initialize database tables with current pages:
 
   $ manage.py block_inventory
 
-You should now be able to search your pages in the Wagtail admin site, under Reports > Block Inventory.
+Admin users should now be able to search pages in the Wagtail admin site, under Reports > Block Inventory.
+
+Other user groups may be granted access to the report by giving them the "Can view" "Page block" permission in Wagtail Group settings.
 
 Compatibility
 -------------

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -1,3 +1,4 @@
+from wagtail.admin.auth import permission_denied
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.views.reports import PageReportView
 from wagtail.models import Page
@@ -45,6 +46,17 @@ class BlockInventoryReportView(PageReportView):
     title = "Block inventory"
     header_icon = "placeholder"
     filterset_class = BlockInventoryFilterSet
+
+    @classmethod
+    def check_permissions(cls, request):
+        return request.user.is_superuser or request.user.has_perm(
+            "wagtailinventory.view_pageblock"
+        )
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.check_permissions(request):
+            return permission_denied(request)
+        return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
         self.queryset = Page.objects.order_by("title")


### PR DESCRIPTION
Currently any Wagtail user with admin permissions may view the block inventory report. This commit adds the ability to leverage the existing wagtailinventory "view_pageblock" permission to grant this ability to non-admin users.

This permission can be granted in the standard Wagtail group view, listed as "Can view" for the "Page block" object type.

Closes #47; see also internal CFPB D&CP#349. Ping @csebianlander since I can't request your review here.

## Testing

To test, run an interactive test session with `tox -e interactive`. First login as the admin user with credentials `admin` / `changeme`. Confirm that the block inventory exists in the Reports sidebar menu and that you can view it.

Then, create a new non-admin user at http://localhost:8000/admin/users/add/. Add this user to the existing Editors group but do not grant it admin permissions.

Log out of the Wagtail admin and log back in using this new user. You'll notice this user won't see the block inventory in the Reports sidebar menu, and if you try to access http://localhost:8000/admin/block-inventory/ directly, you'll be redirected with an error message.

Next, log back in as admin, and edit the Editors group at  http://localhost:8000/admin/groups/2/. Give this group the "Can view" permission for the "Page block" object type. Hit Save.

Finally, log back in as your other user, and confirm that you can now access the block inventory report.

## Screenshots

New permission entry in the Group edit view:

![image](https://github.com/cfpb/wagtail-inventory/assets/654645/73cdc8a8-b09c-4095-ac7f-4476d85099a6)

## Todos

It would be nice to have a better name than "Page block" in the permissions list. At first I thought I could override the PageBlock model's [`verbose_name`](https://docs.djangoproject.com/en/4.2/ref/models/options/#verbose-name) but Wagtail doesn't seem to consistently render this; see https://github.com/wagtail/wagtail/issues/10982. I'd rather get this in now and revisit when possible in future.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested