### PR TITLE
Support Wagtail 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,12 @@ jobs:
           - python: '3.11'
             django: '4.2'
             wagtail: '5.0'
+          - python: '3.11'
+            django: '4.1'
+            wagtail: '5.1'
+          - python: '3.11'
+            django: '4.2'
+            wagtail: '5.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python: ['3.8', '3.11']
         django: ['3.2', '4.1']
-        wagtail: ['4.1', '4.2', '5.0']
+        wagtail: ['4.1', '4.2', '5.0', '5.1']
         include:
           - python: '3.8'
             django: '3.2'

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ This code has been tested for compatibility with:
 
 * Python 3.8+
 * Django 3.2 (LTS), 4.1, 4.2 (LTS)
-* Wagtail 3.0, 4.1 (LTS), 4.2, 5.0
+* Wagtail 3.0, 4.1 (LTS), 4.2, 5.0, 5.1
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     lint,
     python{3.8}-django{3.2}-wagtail{3.0},
     python{3.8,3.11}-django{3.2,4.1}-wagtail{4.1,4.2},
-    python{3.8,3.11}-django{3.2,4.1,4.2}-wagtail{5.0},
+    python{3.8,3.11}-django{3.2,4.1,4.2}-wagtail{5.0,5.1},
     coverage
 
 [testenv]
@@ -24,6 +24,7 @@ deps=
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail4.2: wagtail>=4.2,<5.0
     wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
 
 [testenv:lint]
 basepython=python3.8


### PR DESCRIPTION

- Include explicit support for Wagtail 5.1 in tests
- I have left Wagtail 3 support in place following a [prior PR comment](https://github.com/cfpb/wagtail-inventory/pull/73#issuecomment-1584527147) 

