### PR TITLE
Use PyPI trusted publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,25 +4,28 @@ on:
     types: [published]
   workflow_dispatch:
 
-
 jobs:
   build:
+    name: Build and publish release to PyPI
     runs-on: ubuntu-latest
+    # This uses PyPI trusted publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/p/wagtail-inventory
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip build
-        pip install twine wheel
     - name: Build the package
       run: |
         python -m build
-    - name: Upload to PyPI
-      run: twine upload dist/*
-      env:
-        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
This change uses
[PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) on release. It requires corresponding changes to the wagtail-sharing package on PyPI to configure the GitHub Actions in release.yml to be allowed to publish, but I have already done this.

This is the model that PyPI recommends, and that works for our latest [wagtail-treemodeladmin](https://github.com/cfpb/wagtail-treemodeladmin/blob/main/.github/workflows/release.yml) release.
