### PR TITLE
Update package tooling and boilerplate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         run: |
@@ -31,26 +31,25 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.11']
-        django: ['3.2', '4.2']
-        wagtail: ['4.1', '5.2', '6.0']
-        exclude:
-          - django: '3.2'
-            wagtail: '6.0'
-          - django: '4.2'
-            wagtail: '4.1'
-          - python: '3.11'
-            django: '3.2'
+        python: ['3.8', '3.12']
+        django: ['4.2']
+        wagtail: ['5.2', '6.0', '6.1']
         include:
-          - python: '3.11'
+          - python: '3.12'
+            django: '5.0'
+            wagtail: '5.2'
+          - python: '3.12'
             django: '5.0'
             wagtail: '6.0'
+          - python: '3.12'
+            django: '5.0'
+            wagtail: '6.1'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -60,15 +59,14 @@ jobs:
           pip install tox coveralls
 
       - name: Run tox
-        run: |
-            tox
+        run: tox
         env:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
           path: .coverage.*
 
   coverage:
@@ -78,23 +76,24 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox
+
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: coverage
+          merge-multiple: true
 
       - name: Check coverage
         run: tox -e coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,15 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-    - id: black
-      args: ["wagtailinventory", "setup.py", "--line-length=79"]
-      exclude: migrations
--   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.2.2
-    hooks:
-      - id: ruff
-        exclude: migrations
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["wagtailinventory"]
+-  repo: https://github.com/charliermarsh/ruff-pre-commit
+   rev: v0.5.0
+   hooks:
+     # Run the linter.
+     - id: ruff
+       args: ['--fix']
+     # Run the formatter.
+     - id: ruff-format
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.8
+  hooks:
+    - id: bandit
+      args: ['-c', 'pyproject.toml', '--recursive']
+      additional_dependencies: ['bandit[toml]']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=63", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "wagtail-inventory"
-version = "2.6"
+dynamic = ["version"]
 description = "Wagtail report to filter pages by block content"
 readme = "README.rst"
 requires-python = ">=3.8"
@@ -10,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "tqdm>=4.15.0,<5",
-    "wagtail>=3",
+    "wagtail>=5.2",
     "django-autocomplete-light>=3.9",
 ]
 classifiers = [
@@ -39,72 +43,65 @@ testing = [
 "Bug Reports" = "https://github.com/cfpb/wagtail-inventory/issues"
 "Source" = "https://github.com/cfpb/wagtail-inventory"
 
-[build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [tool.setuptools.package-data]
 inventory = [
     "templates/wagtailinventory/*",
 ]
 
-[tool.black]
-line-length = 79
-target-version = ["py38"]
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.tox
-    | \*.egg-info
-    | _build
-    | build
-    | dist
-    | migrations
-  )/
-)
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 79
-lines_after_imports = 2
-skip = [".tox", "migrations", ".venv", "venv"]
-known_django = ["django"]
-known_wagtail = ["wagtail"]
-default_section = "THIRDPARTY"
-sections = [
-    "STDLIB",
-    "DJANGO",
-    "WAGTAIL",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER"
-]
+[tool.setuptools_scm]
 
 [tool.ruff]
+# Use PEP8 line-length
+line-length = 79
+# Exclude common paths
 exclude = [
     ".git",
     ".tox",
     "__pycache__",
-    "*/migrations/*.py",
-    "*/tests/testapp/migrations/*.py",
-    "docs",
-    ".venv",
-    "venv",
+    "**/migrations/*.py",
 ]
 
 [tool.ruff.lint]
-ignore = []
+ignore = ["E731", ]
+# Select specific rulesets to use
 select = [
+    # pycodestyle
     "E",
+    # pyflakes
     "F",
-    "W",
+    # flake8-bugbear
+    "B",
+    # pyupgrade
+    "UP",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+
+[tool.ruff.lint.isort.sections]
+"django" = ["django"]
+"wagtail" = ["wagtail"]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+section-order = [
+    "future",
+    "standard-library",
+    "django",
+    "wagtail",
+    "third-party",
+    "first-party",
+    "local-folder",
 ]
 
 [tool.coverage.run]
 omit = [
     "wagtailinventory/tests/*",
 ]
+
+[tool.bandit]
+exclude_dirs = [
+    "*/tests/*",
+]
+

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8}-django{3.2}-wagtail{4.1,5.2}
-    python{3.8,3.11}-django{4.2}-wagtail{5.2,6.0}
-    python3.11-django5.0-wagtail6.0
+    python3.8-django{4.2}-wagtail{5.2,6.0,6.1}
+    python3.12-django{4.2,5.0}-wagtail{5.2,6.0,6.1}
     coverage
 
 [testenv]
@@ -14,29 +13,27 @@ commands=
 
 basepython=
     python3.8: python3.8
-    python3.11: python3.11
+    python3.12: python3.12
 
 deps=
-    django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
-    wagtail4.1: wagtail>=4.1,<5.0
-    wagtail5.2: wagtail>=5.2,<5.3
+    wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
 
 [testenv:lint]
-basepython=python3.11
+basepython=python3.12
 deps=
-    black
     ruff
-    isort
+    bandit
 commands=
-    black --check wagtailinventory setup.py testmanage.py
-    ruff wagtailinventory testmanage.py
-    isort --check-only --diff wagtailinventory testmanage.py
+    ruff format --check
+    ruff check wagtailinventory testmanage.py
+    bandit -c "pyproject.toml" -r wagtailinventory testmanage.py
 
 [testenv:coverage]
-basepython=python3.11
+basepython=python3.12
 deps=
     coverage[toml]
     diff_cover
@@ -47,7 +44,7 @@ commands=
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:interactive]
-basepython=python3.11
+basepython=python3.12
 deps=
     Django>=5.0,<5.1
 

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -19,4 +19,4 @@ class PageBlock(models.Model):
     wagtail_reference_index_ignore = True
 
     def __str__(self):
-        return "<{}, {}>".format(self.page, self.block)
+        return f"<{self.page}, {self.block}>"


### PR DESCRIPTION
This change updates our tooling to make a few changes and updates:

- Use Ruff exclusively for formatting, linting, and import-sorting. Ruff can replace Black and isort, and is faster.
- Add Bandit for static security analysis.
- Move to pyproject.toml
- Add setuptools_scm for versioning. This will mean we don't have to manually update a version number in pyproject.toml.
- Run `ruff check --fix` for linting fixes
- Bumps the minimum version of Wagtail to 5.2, the latest LTS.