### PR TITLE
Update for Wagtail 6.2 universal listing reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,13 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.12']
-        django: ['4.2']
-        wagtail: ['5.2', '6.0', '6.1']
+        python: ['3.12']
+        django: ['4.2', '5.0']
+        wagtail: ['6.2']
         include:
-          - python: '3.12'
-            django: '5.0'
-            wagtail: '5.2'
-          - python: '3.12'
-            django: '5.0'
-            wagtail: '6.0'
-          - python: '3.12'
-            django: '5.0'
-            wagtail: '6.1'
+          - python: '3.8'
+            django: '4.2'
+            wagtail: '6.2'
 
     steps:
       - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -18,17 +18,13 @@ Install the package using pip:
 
   $ pip install wagtail-inventory
 
-This will also install `django-autocomplete-light <https://django-autocomplete-light.readthedocs.io/>`_.
-
-Add ``dal``, ``dal_select2``, and ``wagtailinventory`` as installed apps in your Django settings:
+Add `wagtailinventory`` as an installed app in your Django settings:
 
 .. code-block:: python
 
   # in settings.py
   INSTALLED_APPS = (
       ...
-      'dal',
-      'dal_select2',
       'wagtailinventory',
       ...
   )
@@ -54,9 +50,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.8+
-* Django 3.2 (LTS), 4.2 (LTS), 5.0
-* Wagtail 3.0+, including 5.2 (LTS) and 6.0
+* Python 3.8, 3.12
+* Django 4.2 (LTS), 5.0
+* Wagtail 6.2
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,18 +14,13 @@ authors = [
 ]
 dependencies = [
     "tqdm>=4.15.0,<5",
-    "wagtail>=5.2",
-    "django-autocomplete-light>=3.9",
+    "wagtail>=6.2",
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 3",
-    "Framework :: Wagtail :: 4",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python3.8-django{4.2}-wagtail{5.2,6.0,6.1}
-    python3.12-django{4.2,5.0}-wagtail{5.2,6.0,6.1}
+    python3.8-django{4.2}-wagtail{6.2}
+    python3.12-django{4.2,5.0}-wagtail{6.2}
     coverage
 
 [testenv]
@@ -18,9 +18,7 @@ basepython=
 deps=
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
-    wagtail5.2: wagtail>=5.2,<6.0
-    wagtail6.0: wagtail>=6.0,<6.1
-    wagtail6.1: wagtail>=6.1,<6.2
+    wagtail6.2: wagtail>=6.2,<6.3
 
 [testenv:lint]
 basepython=python3.12

--- a/wagtailinventory/tests/settings.py
+++ b/wagtailinventory/tests/settings.py
@@ -54,8 +54,6 @@ INSTALLED_APPS = (
     )
     + WAGTAIL_APPS
     + (
-        "dal",
-        "dal_select2",
         "wagtailinventory",
         "wagtailinventory.tests.testapp",
     )

--- a/wagtailinventory/tests/test_views.py
+++ b/wagtailinventory/tests/test_views.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 
@@ -9,37 +8,6 @@ from wagtail.test.utils import WagtailTestUtils
 
 
 User = get_user_model()
-
-
-class BlockAutocompleteViewTestCase(WagtailTestUtils, TestCase):
-    fixtures = ["test_blocks.json"]
-
-    def setUp(self):
-        self.login()
-
-    def test_get_list(self):
-        call_command("block_inventory", verbosity=0)
-        response = self.client.get(
-            reverse("wagtailinventory:block_autocomplete")
-        )
-
-        json_response = response.json()
-        self.assertIn("results", json_response)
-
-        results = json_response["results"]
-
-        # There are six unique block types in our test fixture
-        self.assertEqual(len(results), 6)
-
-        # Make sure that one of the results matches our expected id/text
-        # pairing
-        self.assertIn(
-            {
-                "id": "wagtail.blocks.field_block.CharBlock",
-                "text": "wagtail.blocks.field_block.CharBlock",
-            },
-            results,
-        )
 
 
 class BlockInventoryReportViewTestCase(WagtailTestUtils, TestCase):

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -1,3 +1,5 @@
+from django.forms.widgets import SelectMultiple
+
 from wagtail.admin.auth import permission_denied
 from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
 from wagtail.admin.views.reports import PageReportView
@@ -10,7 +12,7 @@ from wagtailinventory.models import PageBlock
 
 def get_block_choices():
     return [
-        (page_block, page_block.rsplit(".", 1)[1])
+        (page_block, page_block)
         for page_block in PageBlock.objects.distinct()
         .order_by("block")
         .values_list("block", flat=True)
@@ -23,6 +25,7 @@ class BlockInventoryFilterSet(WagtailFilterSet):
         label="Include Blocks",
         distinct=True,
         choices=get_block_choices,
+        widget=SelectMultiple(attrs={"style": "overflow: auto"}),
     )
     exclude_page_blocks = django_filters.MultipleChoiceFilter(
         field_name="page_blocks__block",
@@ -30,6 +33,7 @@ class BlockInventoryFilterSet(WagtailFilterSet):
         distinct=True,
         exclude=True,
         choices=get_block_choices,
+        widget=SelectMultiple(attrs={"style": "overflow: auto"}),
     )
     content_type = ContentTypeFilter(
         label="Page Type",

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -9,10 +9,7 @@ from wagtailinventory.helpers import (
     delete_page_inventory,
     update_page_inventory,
 )
-from wagtailinventory.views import (
-    BlockAutocompleteView,
-    BlockInventoryReportView,
-)
+from wagtailinventory.views import BlockInventoryReportView
 
 
 @hooks.register("after_create_page")
@@ -61,9 +58,9 @@ def register_inventory_report_url():
             name="block_inventory_report",
         ),
         path(
-            "block-autocomplete/",
-            BlockAutocompleteView.as_view(),
-            name="block_autocomplete",
+            "results/",
+            BlockInventoryReportView.as_view(results_only=True),
+            name="block_inventory_report_results",
         ),
     ]
 


### PR DESCRIPTION
This change updates the Wagtail Block Inventory report to be a universal listing, per the [changes in Wagtail 6.2](https://docs.wagtail.org/en/latest/releases/6.2.html#changes-to-report-views-with-the-new-universal-listings-ui).

Because the way universal listing filters work doesn't play well with django-autocomplete-lite and Select2, I've removed that dependency.

Finally, because of the switch to universal listings, rather than continue to support old-and-new style reports, I've removed support for Wagtail < 6.2. This will necessitate a major release.

This PR will need to be updated when 6.2 is released.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
