### PR TITLE
Fix missing coverage files in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
           path: .coverage.*
+          include-hidden-files: true
 
   coverage:
     name: coverage


### PR DESCRIPTION
As of September 2nd, using the `upload-artifact` GitHub Action no longer uploads hidden files by default:

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

This breaks uploading of `.coverage.*` files used to combine multiple coverage reports.

The `upload-artifact` README now includes [this guidance](https://github.com/actions/upload-artifact?tab=readme-ov-file#uploading-hidden-files) on including hidden files.