### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Install dependencies
         run: |
@@ -31,16 +31,16 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.12']
-        django: ['4.2', '5.0']
-        wagtail: ['6.2']
+        python: ['3.12', '3.13']
+        django: ['5.1']
+        wagtail: ['6.3', '6.4']
         include:
-          - python: '3.8'
+          - python: '3.10'
             django: '4.2'
             wagtail: '6.2'
-          - python: '3.12'
-            django: '5.1'
-            wagtail: '6.3'
+          - python: '3.13'
+            django: '4.2'
+            wagtail: '6.2'
 
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -  repo: https://github.com/charliermarsh/ruff-pre-commit
-   rev: v0.5.0
+   rev: v0.14.3
    hooks:
      # Run the linter.
      - id: ruff
@@ -8,7 +8,7 @@ repos:
      # Run the formatter.
      - id: ruff-format
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.7.8
+  rev: 1.8.6
   hooks:
     - id: bandit
       args: ['-c', 'pyproject.toml', '--recursive']

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.8, 3.12
-* Django 4.2 (LTS), 5.0, 5.1
-* Wagtail 6.2, 6.3 (LTS)
+* Python 3.10, 3.12, 3.13
+* Django 4.2 (LTS), 5.1
+* Wagtail 6.2, 6.3 (LTS), 6.4
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wagtail-inventory"
 dynamic = ["version"]
 description = "Wagtail report to filter pages by block content"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "CC0"}
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
@@ -27,6 +27,10 @@ classifiers = [
     "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python3.8-django{4.2}-wagtail{6.2}
-    python3.12-django{4.2,5.0}-wagtail{6.2,6.3}
-    python3.12-django5.1-wagtail6.3
+    python{3.10,3.13}-django4.2-wagtail6.2
+    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
     coverage
 
 [testenv]
@@ -13,18 +12,19 @@ commands=
     python -b -m coverage run --parallel-mode --source='wagtailinventory' {toxinidir}/testmanage.py test {posargs}
 
 basepython=
-    python3.8: python3.8
+    python3.10: python3.10
     python3.12: python3.12
+    python3.13: python3.13
 
 deps=
     django4.2: Django>=4.2,<4.3
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
 
 [testenv:lint]
-basepython=python3.12
+basepython=python3.13
 deps=
     ruff
     bandit
@@ -34,7 +34,7 @@ commands=
     bandit -c "pyproject.toml" -r wagtailinventory testmanage.py
 
 [testenv:coverage]
-basepython=python3.12
+basepython=python3.13
 deps=
     coverage[toml]
     diff_cover
@@ -45,9 +45,9 @@ commands=
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:interactive]
-basepython=python3.12
+basepython=python3.13
 deps=
-    Django>=5.0,<5.2
+    Django>=5.1,<5.2
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations

--- a/wagtailinventory/helpers.py
+++ b/wagtailinventory/helpers.py
@@ -1,17 +1,20 @@
 from itertools import chain
 
+from django.db.models import QuerySet
+
 from wagtail.blocks import ListBlock, StreamBlock, StructBlock
 from wagtail.fields import StreamField
+from wagtail.models import Page
 
 from wagtailinventory.models import PageBlock
 
 
-def get_block_name(block):
+def get_block_name(block: object) -> str:
     return block.__module__ + "." + block.__class__.__name__
 
 
-def get_page_blocks(page):
-    blocks = []
+def get_page_blocks(page: Page) -> list[str]:
+    blocks: list = []
 
     for field in page.specific._meta.fields:
         if not isinstance(field, StreamField):
@@ -23,16 +26,16 @@ def get_page_blocks(page):
     return sorted(set(map(get_block_name, blocks)))
 
 
-def get_field_blocks(value):
-    block = getattr(value, "block", None)
-    blocks = [block] if block else []
+def get_field_blocks(value: object) -> list:
+    block: object | None = getattr(value, "block", None)
+    blocks: list = [block] if block else []
 
     if isinstance(block, StructBlock):
         if hasattr(value, "bound_blocks"):
             child_blocks = value.bound_blocks.values()
         else:
             child_blocks = [value.value]
-    elif isinstance(block, (ListBlock, StreamBlock)):
+    elif isinstance(block, ListBlock | StreamBlock):
         child_blocks = value.value
     else:
         child_blocks = []
@@ -42,7 +45,7 @@ def get_field_blocks(value):
     return blocks
 
 
-def get_page_inventory(page=None):
+def get_page_inventory(page: Page | None = None) -> QuerySet:
     inventory = PageBlock.objects.all()
 
     if page:
@@ -51,7 +54,7 @@ def get_page_inventory(page=None):
     return inventory
 
 
-def create_page_inventory(page):
+def create_page_inventory(page: Page) -> list[PageBlock]:
     page_blocks = get_page_blocks(page)
 
     return [
@@ -60,11 +63,11 @@ def create_page_inventory(page):
     ]
 
 
-def delete_page_inventory(page=None):
+def delete_page_inventory(page: Page | None = None) -> None:
     get_page_inventory(page).delete()
 
 
-def update_page_inventory(page):
+def update_page_inventory(page: Page) -> None:
     page_blocks = create_page_inventory(page)
 
     for page_block in get_page_inventory(page):

--- a/wagtailinventory/management/commands/block_inventory.py
+++ b/wagtailinventory/management/commands/block_inventory.py
@@ -11,7 +11,7 @@ from wagtailinventory.helpers import (
 
 
 class Command(BaseCommand):
-    def handle(self, *args, **options):
+    def handle(self, *args, **options) -> None:
         delete_page_inventory()
 
         pages = Page.objects.all()

--- a/wagtailinventory/models.py
+++ b/wagtailinventory/models.py
@@ -18,5 +18,5 @@ class PageBlock(models.Model):
 
     wagtail_reference_index_ignore = True
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"<{self.page}, {self.block}>"

--- a/wagtailinventory/views.py
+++ b/wagtailinventory/views.py
@@ -1,4 +1,6 @@
+from django.db.models import QuerySet
 from django.forms.widgets import SelectMultiple
+from django.http import HttpRequest, HttpResponse
 
 from wagtail.admin.auth import permission_denied
 from wagtail.admin.filters import ContentTypeFilter, WagtailFilterSet
@@ -10,7 +12,7 @@ import django_filters
 from wagtailinventory.models import PageBlock
 
 
-def get_block_choices():
+def get_block_choices() -> list[tuple[str, str]]:
     return [
         (page_block, page_block)
         for page_block in PageBlock.objects.distinct()
@@ -53,16 +55,16 @@ class BlockInventoryReportView(PageReportView):
     index_results_url_name = "wagtailinventory:block_inventory_report_results"
 
     @classmethod
-    def check_permissions(cls, request):
+    def check_permissions(cls, request: HttpRequest) -> bool:
         return request.user.is_superuser or request.user.has_perm(
             "wagtailinventory.view_pageblock"
         )
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         if not self.check_permissions(request):
             return permission_denied(request)
         return super().dispatch(request, *args, **kwargs)
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet:
         self.queryset = Page.objects.order_by("title")
         return super().get_queryset()

--- a/wagtailinventory/wagtail_hooks.py
+++ b/wagtailinventory/wagtail_hooks.py
@@ -1,8 +1,11 @@
 from django.contrib.auth.models import Permission
+from django.db.models import QuerySet
+from django.http import HttpRequest
 from django.urls import include, path, reverse
 
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
+from wagtail.models import Page
 
 from wagtailinventory.helpers import (
     create_page_inventory,
@@ -13,22 +16,22 @@ from wagtailinventory.views import BlockInventoryReportView
 
 
 @hooks.register("after_create_page")
-def do_after_page_create(request, page):
+def do_after_page_create(request: HttpRequest, page: Page) -> None:
     create_page_inventory(page)
 
 
 @hooks.register("after_edit_page")
-def do_after_page_edit(request, page):
+def do_after_page_edit(request: HttpRequest, page: Page) -> None:
     update_page_inventory(page)
 
 
 @hooks.register("after_delete_page")
-def do_after_page_dete(request, page):
+def do_after_page_dete(request: HttpRequest, page: Page) -> None:
     delete_page_inventory(page)
 
 
 @hooks.register("register_permissions")
-def register_permissions():
+def register_permissions() -> QuerySet:
     return Permission.objects.filter(
         content_type__app_label="wagtailinventory",
         codename__in=["view_pageblock"],
@@ -36,12 +39,12 @@ def register_permissions():
 
 
 class CanViewBlockInventoryMenuItem(MenuItem):
-    def is_shown(self, request):
+    def is_shown(self, request: HttpRequest) -> bool:
         return BlockInventoryReportView.check_permissions(request)
 
 
 @hooks.register("register_reports_menu_item")
-def register_inventory_report_menu_item():
+def register_inventory_report_menu_item() -> CanViewBlockInventoryMenuItem:
     return CanViewBlockInventoryMenuItem(
         "Block inventory",
         reverse("wagtailinventory:block_inventory_report"),
@@ -50,7 +53,7 @@ def register_inventory_report_menu_item():
 
 
 @hooks.register("register_admin_urls")
-def register_inventory_report_url():
+def register_inventory_report_url() -> list:
     report_urls = [
         path(
             "",


### PR DESCRIPTION
Drops support for Python 3.8 (EOL 10/7/24) and 3.9 (EOL 10/31/25).

Updates test matrix to test these versions:

- python3.10-django4.2-wagtail6.2
- python3.12-django{4.2,5.1}-wagtail{6.2,6.4}
- python3.13-django5.1-wagtail6.4