### PR TITLE
Update wagtail-inventory for Wagtail 7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -31,22 +31,15 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.12', '3.13']
-        django: ['5.1']
-        wagtail: ['6.3', '6.4']
-        include:
-          - python: '3.10'
-            django: '4.2'
-            wagtail: '6.2'
-          - python: '3.13'
-            django: '4.2'
-            wagtail: '6.2'
+        python: ["3.12", "3.13"]
+        django: ["5.2"]
+        wagtail: ["6.3", "6.4", "7.0"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@6
         with:
           python-version: ${{ matrix.python }}
 
@@ -61,7 +54,7 @@ jobs:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python }}-${{ matrix.django }}-${{ matrix.wagtail }}
           path: .coverage.*
@@ -74,12 +67,12 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -89,7 +82,7 @@ jobs:
           pip install tox
 
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ Compatibility
 
 This code has been tested for compatibility with:
 
-* Python 3.10, 3.12, 3.13
-* Django 4.2 (LTS), 5.1
-* Wagtail 6.2, 6.3 (LTS), 6.4
+* Python 3.12, 3.13
+* Django 5.2 (LTS)
+* Wagtail 6.3 (LTS), 6.4, 7.0
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wagtail-inventory"
 dynamic = ["version"]
 description = "Wagtail report to filter pages by block content"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {text = "CC0"}
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
@@ -18,17 +18,14 @@ dependencies = [
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.12,3.13}-django{5.2}-wagtail{6.3,6.4,7.0}
+    python{3.12,3.13}-django5.2-wagtail{6.3,6.4,7.0}
     coverage
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.10,3.13}-django4.2-wagtail6.2
-    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
+    python{3.12,3.13}-django{5.2}-wagtail{6.3,6.4,7.0}
     coverage
 
 [testenv]
@@ -12,16 +11,14 @@ commands=
     python -b -m coverage run --parallel-mode --source='wagtailinventory' {toxinidir}/testmanage.py test {posargs}
 
 basepython=
-    python3.10: python3.10
     python3.12: python3.12
     python3.13: python3.13
 
 deps=
-    django4.2: Django>=4.2,<4.3
-    django5.1: Django>=5.1,<5.2
-    wagtail6.2: wagtail>=6.2,<6.3
+    django5.2: Django>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 [testenv:lint]
 basepython=python3.13
@@ -47,7 +44,8 @@ commands=
 [testenv:interactive]
 basepython=python3.13
 deps=
-    Django>=5.1,<5.2
+    Django>=5.2,<5.3
+    wagtail>=7.0,<7.1
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations


### PR DESCRIPTION
This pull request updates the package to support Wagtail 7, while dropping support for older versions of python and django.

## Changes
- add support for Wagtail 7.0
- remove support for django 4.2 and 5.1
- remove support for python 3.10
