### PR TITLE
Wagtail 7.4 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,11 @@ jobs:
     strategy:
       matrix:
         python: ["3.12", "3.13"]
-        django: ["5.2"]
-        wagtail: ["6.3", "6.4", "7.0"]
+        django: ["5.2", "6.0"]
+        wagtail: ["7.0", "7.3", "7.4"]
+        exclude:
+          - django: "6.0"
+            wagtail: "7.0"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,13 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.12", "3.13"]
+        python: ["3.12", "3.13", "3.14"]
         django: ["5.2", "6.0"]
         wagtail: ["7.0", "7.3", "7.4"]
         exclude:
           - django: "6.0"
+            wagtail: "7.0"
+          - python: "3.14"
             wagtail: "7.0"
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -  repo: https://github.com/charliermarsh/ruff-pre-commit
-   rev: v0.14.3
+   rev: v0.15.14
    hooks:
      # Run the linter.
      - id: ruff
@@ -8,7 +8,7 @@ repos:
      # Run the formatter.
      - id: ruff-format
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.8.6
+  rev: 1.9.4
   hooks:
     - id: bandit
       args: ['-c', 'pyproject.toml', '--recursive']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add support for Wagtail 7.3, 7.4 LTS and Django 6.0.
+- Add support for Python 3.14
 - Drop support for Wagtail 6.3 LTS and 6.4 (both end-of-life) and remove dead Django 1.x/2.x compatibility shim from test URL config.
 - Add explicit `locale` to test page fixtures, required by Wagtail 7.3+.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Add support for Wagtail 7.3, 7.4 LTS and Django 6.0.
+- Drop support for Wagtail 6.3 LTS and 6.4 (both end-of-life) and remove dead Django 1.x/2.x compatibility shim from test URL config.
+- Add explicit `locale` to test page fixtures, required by Wagtail 7.3+.
+
+## Previous releases
+
 See the project repository release history at:
 
 https://github.com/cfpb/wagtail-inventory/releases

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,8 @@ Compatibility
 This code has been tested for compatibility with:
 
 * Python 3.12, 3.13
-* Django 5.2 (LTS)
-* Wagtail 6.3 (LTS), 6.4, 7.0
+* Django 5.2 (LTS), 6.0
+* Wagtail 7.0 (LTS), 7.3, 7.4 (LTS)
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-inventory/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ authors = [
 ]
 dependencies = [
     "tqdm>=4.15.0,<5",
-    "wagtail>=6.2",
+    "wagtail>=7.0",
 ]
 classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.12,3.13}-django5.2-wagtail{7.0,7.3,7.4}
-    python{3.12,3.13}-django6.0-wagtail{7.3,7.4}
+    python{3.12,3.13}-django5.2-wagtail7.0
+    python{3.12,3.13,3.14}-django{5.2,6.0}-wagtail{7.3,7.4}
     coverage
 
 [testenv]
@@ -14,6 +14,7 @@ commands=
 basepython=
     python3.12: python3.12
     python3.13: python3.13
+    python3.14: python3.14
 
 deps=
     django5.2: Django>=5.2,<5.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.12,3.13}-django5.2-wagtail{6.3,6.4,7.0}
+    python{3.12,3.13}-django5.2-wagtail{7.0,7.3,7.4}
+    python{3.12,3.13}-django6.0-wagtail{7.3,7.4}
     coverage
 
 [testenv]
@@ -16,9 +17,10 @@ basepython=
 
 deps=
     django5.2: Django>=5.2,<5.3
-    wagtail6.3: wagtail>=6.3,<6.4
-    wagtail6.4: wagtail>=6.4,<6.5
+    django6.0: Django>=6.0,<6.1
     wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.3: wagtail>=7.3,<7.4
+    wagtail7.4: wagtail>=7.4,<7.5
 
 [testenv:lint]
 basepython=python3.13
@@ -45,7 +47,7 @@ commands=
 basepython=python3.13
 deps=
     Django>=5.2,<5.3
-    wagtail>=7.0,<7.1
+    wagtail>=7.4,<7.5
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations

--- a/wagtailinventory/fixtures/test_blocks.json
+++ b/wagtailinventory/fixtures/test_blocks.json
@@ -26,7 +26,8 @@
         "first_published_at": null,
         "last_published_at": null,
         "latest_revision_created_at": "2018-06-11T11:43:21.991Z",
-        "live_revision": null
+        "live_revision": null,
+        "locale": 1
     }
 },
 {
@@ -56,7 +57,8 @@
         "first_published_at": null,
         "last_published_at": null,
         "latest_revision_created_at": "2018-06-11T11:43:38.252Z",
-        "live_revision": null
+        "live_revision": null,
+        "locale": 1
     }
 },
 {
@@ -86,7 +88,8 @@
         "first_published_at": null,
         "last_published_at": null,
         "latest_revision_created_at": "2018-06-11T11:44:22.660Z",
-        "live_revision": null
+        "live_revision": null,
+        "locale": 1
     }
 },
 {
@@ -116,7 +119,8 @@
         "first_published_at": null,
         "last_published_at": null,
         "latest_revision_created_at": "2018-06-11T11:44:47.772Z",
-        "live_revision": null
+        "live_revision": null,
+        "locale": 1
     }
 },
 {
@@ -146,7 +150,8 @@
         "first_published_at": null,
         "last_published_at": null,
         "latest_revision_created_at": "2018-06-11T11:45:01.819Z",
-        "live_revision": null
+        "live_revision": null,
+        "locale": 1
     }
 },
 {

--- a/wagtailinventory/tests/urls.py
+++ b/wagtailinventory/tests/urls.py
@@ -1,15 +1,9 @@
 from django.conf import settings
+from django.urls import include, re_path
 
 from wagtail import urls as wagtailcore_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
-
-
-try:
-    from django.urls import include, re_path
-except ImportError:
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
 
 
 urlpatterns = [


### PR DESCRIPTION
Maintenance pass to extend the support window: add Python 3.14, Django 6.0, and Wagtail 7.3 / 7.4 (LTS); drop end-of-life Wagtail 6.x; refresh tooling and test fixtures.

## Additions

- Add support for Python 3.14 (tested against Wagtail 7.3+ on Django 5.2 and 6.0; Wagtail 7.0 LTS does not support Python 3.14 and is excluded from those cells).
- Add support for Django 6.0 (paired with Wagtail 7.3 and 7.4 LTS).
- Add support for Wagtail 7.3 and Wagtail 7.4 LTS.
- Add `Framework :: Django :: 6.0` and `Programming Language :: Python :: 3.14` classifiers.
- Add `locale` field to test page fixtures (required by Wagtail 7.3+).

## Removals

- Drop support for Wagtail 6.3 LTS and Wagtail 6.4 (both end-of-life).
- Remove dead Django 1.x / 2.x `try/except ImportError` shim from `wagtailinventory/tests/urls.py` (all supported Django versions provide `django.urls.include` / `re_path`).
- Remove the `Framework :: Wagtail :: 6` classifier.

## Changes

- Raise `wagtail` minimum from `>=6.2` to `>=7.0` in `pyproject.toml`.
- Update tox envlist:
  - `python{3.12,3.13}-django5.2-wagtail7.0`
  - `python{3.12,3.13,3.14}-django{5.2,6.0}-wagtail{7.3,7.4}`
- Update GitHub Actions test matrix to include Python 3.14, with excludes for `python: "3.14" + wagtail: "7.0"` and the existing `django: "6.0" + wagtail: "7.0"`.
- Bump pre-commit hook versions: `ruff-pre-commit` v0.14.3 → v0.15.14, `bandit` 1.8.6 → 1.9.4.
- Update README compatibility section to reflect new supported versions.
- Update `Unreleased` section of `CHANGELOG.md`.

## Testing

1. Run `tox -e lint`.
2. Run the full tox matrix locally or via CI — each Python × Django × Wagtail cell should pass all 14 tests.
3. Spot-check Python 3.14 cells locally:
   - `tox -e python3.14-django5.2-wagtail7.3`
   - `tox -e python3.14-django6.0-wagtail7.4`
4. Confirm `tox -e interactive` still boots the test app against Wagtail 7.4 / Django 5.2.

## Screenshots

_N/A — no UI changes._

## Notes

- Python 3.14 was released 2025-10-07 and is in bugfix support. Django 5.2 supports Python 3.14 from 5.2.8 onward; the `Django>=5.2,<5.3` specifier resolves to a compatible patch.
- Wagtail 7.0 LTS supports Python 3.9–3.13 only, so the matrix intentionally excludes Python 3.14 × Wagtail 7.0.
- Django 5.2 must remain in the support range while Wagtail 7.0 LTS is supported, since Wagtail 7.0 does not support Django 6.0.

## Todos

- _None outstanding._

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output) — N/A, no new functions
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:) — N/A, no UI changes
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [x] No linting errors or warnings
- [ ] JavaScript tests are passing
